### PR TITLE
Fixed issue with error message display

### DIFF
--- a/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/Analysis.java
+++ b/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/Analysis.java
@@ -243,6 +243,9 @@ public class Analysis implements BioObserver
   private Analysis()
   {
     properties = new AnalysisProperties("", "", "", false);
+    
+    properties.addObserver(this);
+    
     propertiesMap = new HashMap<String, String>();
   }
 

--- a/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/Analysis.java
+++ b/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/Analysis.java
@@ -369,7 +369,7 @@ public class Analysis implements BioObserver
     	  new File(properties.getDirectory()).mkdir();
       }
       /* Flattening happens here */
-      BioModel biomodel = new BioModel(root);
+      BioModel biomodel =  BioModel.createBioModel(root, this);
       biomodel.addObserver(this);
       biomodel.load(root + File.separator + modelSource + "_");
       SBMLDocument flatten = biomodel.flattenModel(true);

--- a/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/Run.java
+++ b/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/Run.java
@@ -197,7 +197,7 @@ public class Run extends CoreObservable implements ActionListener
     }
   }
 
-  private int executeFBA() throws XMLStreamException, IOException
+  private int executeFBA() throws XMLStreamException, IOException, BioSimException
   {
     int exitValue = 255;
 
@@ -434,7 +434,7 @@ public class Run extends CoreObservable implements ActionListener
     return 0;
   }
 
-  private int executeNary() throws XMLStreamException, IOException
+  private int executeNary() throws XMLStreamException, IOException, BioSimException
   {
     String modelFile = properties.getModelFile();
     String directory = properties.getDirectory();
@@ -811,7 +811,7 @@ public class Run extends CoreObservable implements ActionListener
     return exitValue;
   }
 
-  private int executeSBML() throws IOException, HeadlessException, XMLStreamException, InterruptedException
+  private int executeSBML() throws IOException, HeadlessException, XMLStreamException, InterruptedException, BioSimException
   {
     int exitValue = 255;
 

--- a/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/Run.java
+++ b/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/Run.java
@@ -322,7 +322,7 @@ public class Run extends CoreObservable implements ActionListener
       }
     }
     sg = new StateGraph(lhpnFile);
-
+    this.addObservable(sg);
     BuildStateGraphThread buildStateGraph = new BuildStateGraphThread(sg, null);
     buildStateGraph.start();
     buildStateGraph.join();

--- a/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/Run.java
+++ b/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/Run.java
@@ -201,6 +201,7 @@ public class Run extends CoreObservable implements ActionListener
     int exitValue = 255;
 
     FluxBalanceAnalysis fluxBalanceAnalysis = new FluxBalanceAnalysis(properties.getDirectory()+File.separator, properties.getModelFile(), properties.getSimulationProperties().getAbsError());
+    this.addObservable(fluxBalanceAnalysis);
     exitValue = fluxBalanceAnalysis.PerformFluxBalanceAnalysis();
 
     if (exitValue == 1)

--- a/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/Run.java
+++ b/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/Run.java
@@ -182,17 +182,17 @@ public class Run extends CoreObservable implements ActionListener
   {
     if (exitValue == 143)
     {
-      message.setErrorDialog("The simulation was" + " canceled by the user.", "Canceled Simulation");
+      message.setDialog("Canceled Simulation", "The simulation was" + " canceled by the user.");
       this.notifyObservers(message);
     }
     else if (exitValue == 139)
     {
-      message.setErrorDialog("The selected model is not a valid sbml file." + "\nYou must select an sbml file.", "Not An SBML File");
+      message.setErrorDialog("Not An SBML File", "The selected model is not a valid sbml file." + "\nYou must select an sbml file.");
       this.notifyObservers(message);
     }
     else if(exitValue != 0)
     {
-      message.setErrorDialog( "Error In Execution!\n" + "Bad Return Value!\n" + "The reb2sac program returned " + exitValue + " as an exit value.", "Error");
+      message.setErrorDialog("Error In Execution!", "Bad Return Value!\n" + "The reb2sac program returned " + exitValue + " as an exit value.");
       this.notifyObservers(message);
     }
   }

--- a/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/Run.java
+++ b/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/Run.java
@@ -47,6 +47,7 @@ import edu.utah.ece.async.ibiosim.dataModels.biomodel.parser.BioModel;
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.util.SBMLutilities;
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.util.Utility;
 import edu.utah.ece.async.ibiosim.dataModels.util.Executables;
+import edu.utah.ece.async.ibiosim.dataModels.util.GlobalConstants;
 import edu.utah.ece.async.ibiosim.dataModels.util.Message;
 import edu.utah.ece.async.ibiosim.dataModels.util.MutableString;
 import edu.utah.ece.async.ibiosim.dataModels.util.exceptions.BioSimException;
@@ -290,8 +291,7 @@ public class Run extends CoreObservable implements ActionListener
       ArrayList<Object[]> conLevel = new ArrayList<Object[]>();
       retrieveSpeciesAndConLevels(specs, conLevel);
 
-      BioModel bioModel = new BioModel(properties.getRoot());
-      bioModel.addObservable(this);
+      BioModel bioModel = BioModel.createBioModel(properties.getRoot(), this);
       bioModel.load(root + File.separator + filename);
       if (bioModel.flattenModel(true) != null)
       {
@@ -351,7 +351,7 @@ public class Run extends CoreObservable implements ActionListener
         }
         else
         {
-          BioModel gcm = new BioModel(root);
+          BioModel gcm = BioModel.createBioModel(root, this);
           gcm.load(root + File.separator + filename);
           ArrayList<Property> propList = new ArrayList<Property>();
           if (prop == null)
@@ -445,7 +445,7 @@ public class Run extends CoreObservable implements ActionListener
     ArrayList<String> specs = new ArrayList<String>();
     ArrayList<Object[]> conLevel = new ArrayList<Object[]>();
     retrieveSpeciesAndConLevels(specs, conLevel);
-    BioModel bioModel = new BioModel(root);
+    BioModel bioModel = BioModel.createBioModel(properties.getRoot(), this);
     //TODO: check
     bioModel.load(root + File.separator + modelFile);
     String prop = null;
@@ -624,7 +624,7 @@ public class Run extends CoreObservable implements ActionListener
       ArrayList<String> specs = new ArrayList<String>();
       ArrayList<Object[]> conLevel = new ArrayList<Object[]>();
       retrieveSpeciesAndConLevels(specs, conLevel);
-      BioModel bioModel = new BioModel(root);
+      BioModel bioModel = BioModel.createBioModel(properties.getRoot(), this);
       bioModel.load(root + File.separator + properties.getFilename());
       if (bioModel.flattenModel(true) != null)
       {
@@ -899,7 +899,7 @@ public class Run extends CoreObservable implements ActionListener
         ArrayList<Object[]> conLevel = new ArrayList<Object[]>();
         String directory = properties.getDirectory();
         retrieveSpeciesAndConLevels(specs, conLevel);
-        BioModel bioModel = new BioModel(root);
+        BioModel bioModel = BioModel.createBioModel(properties.getRoot(), this);
         bioModel.load(root + File.separator + properties.getModelFile());
 
         if (bioModel.flattenModel(true) != null)

--- a/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/fba/FluxBalanceAnalysis.java
+++ b/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/fba/FluxBalanceAnalysis.java
@@ -35,6 +35,7 @@ import org.sbml.jsbml.SpeciesReference;
 import com.joptimizer.optimizers.*;
 
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.util.SBMLutilities;
+import edu.utah.ece.async.ibiosim.dataModels.util.observe.CoreObservable;
 
 /**
  * 
@@ -44,8 +45,8 @@ import edu.utah.ece.async.ibiosim.dataModels.biomodel.util.SBMLutilities;
  * @author <a href="http://www.async.ece.utah.edu/ibiosim#Credits"> iBioSim Contributors </a>
  * @version %I%
  */
-public class FluxBalanceAnalysis {
-	
+public class FluxBalanceAnalysis extends CoreObservable
+{
 	private String root;
 	
 	private Model model;

--- a/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/fba/FluxBalanceAnalysis.java
+++ b/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/fba/FluxBalanceAnalysis.java
@@ -35,6 +35,7 @@ import org.sbml.jsbml.SpeciesReference;
 import com.joptimizer.optimizers.*;
 
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.util.SBMLutilities;
+import edu.utah.ece.async.ibiosim.dataModels.util.exceptions.BioSimException;
 import edu.utah.ece.async.ibiosim.dataModels.util.observe.CoreObservable;
 
 /**
@@ -66,12 +67,13 @@ public class FluxBalanceAnalysis extends CoreObservable
 	 * 
 	 * @throws XMLStreamException - problem with the sbml document
 	 * @throws IOException - i/o problem
+	 * @throws BioSimException - if the sbml model is invalid.
 	 */
-	public FluxBalanceAnalysis(String root,String sbmlFileName,double absError) throws XMLStreamException, IOException {
+	public FluxBalanceAnalysis(String root,String sbmlFileName,double absError) throws XMLStreamException, IOException, BioSimException {
 		this.root = root;
 		this.absError = absError;
 		fluxes = new HashMap<String,Double>();
-		SBMLDocument sbml = SBMLutilities.readSBML(root + sbmlFileName);
+		SBMLDocument sbml = SBMLutilities.readSBML(root + sbmlFileName, this, null);
 		model = sbml.getModel();
 		fbc = SBMLutilities.getFBCModelPlugin(sbml.getModel(),true);
 	}

--- a/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/properties/AdvancedProperties.java
+++ b/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/properties/AdvancedProperties.java
@@ -16,6 +16,8 @@ package edu.utah.ece.async.ibiosim.analysis.properties;
 import java.util.ArrayList;
 import java.util.List;
 
+import edu.utah.ece.async.ibiosim.dataModels.util.observe.CoreObservable;
+
 /**
  * The advanced properties contains information associated with model abstraction parameters.
  * 
@@ -25,7 +27,8 @@ import java.util.List;
  * @version $Rev$
  * @version %I%
  */
-public class AdvancedProperties {
+public class AdvancedProperties extends CoreObservable
+{
 
   private List<String> preAbs, loopAbs, postAbs;
   

--- a/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/properties/AnalysisProperties.java
+++ b/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/properties/AnalysisProperties.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.prefs.Preferences;
 
 import edu.utah.ece.async.ibiosim.dataModels.util.Executables;
+import edu.utah.ece.async.ibiosim.dataModels.util.observe.CoreObservable;
 
 /**
  * The AnalysisProperties class incorporates all of the necessary information to run analysis in iBioSim,
@@ -37,7 +38,7 @@ import edu.utah.ece.async.ibiosim.dataModels.util.Executables;
  * @version $Rev$
  * @version %I%
  */
-public final class AnalysisProperties 
+public final class AnalysisProperties extends CoreObservable
 {
   
   private static enum UserInterval
@@ -111,10 +112,16 @@ public final class AnalysisProperties
     this.userInterval = UserInterval.PRINT_INTERVAL;
     this.sim = "Runge-Kutta-Fehlberg (Hierarchical)";
     this.tasks = new ArrayList<String>();
+    
     this.advProperties = new AdvancedProperties();
     this.incProperties = new IncrementalProperties();
     this.simProperties = new SimulationProperties();
     this.verifProperties = new VerificationProperties();
+    
+    this.addObservable(advProperties);
+    this.addObservable(incProperties);
+    this.addObservable(simProperties);
+    this.addObservable(verifProperties);
   }
 
   /**

--- a/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/properties/IncrementalProperties.java
+++ b/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/properties/IncrementalProperties.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package edu.utah.ece.async.ibiosim.analysis.properties;
 
+import edu.utah.ece.async.ibiosim.dataModels.util.observe.CoreObservable;
+
 /**
  * The incremental properties contains information used for running iSSA.
  * 
@@ -22,7 +24,8 @@ package edu.utah.ece.async.ibiosim.analysis.properties;
  * @version $Rev$
  * @version %I%
  */
-public class IncrementalProperties {
+public final class IncrementalProperties extends CoreObservable
+{
 
   private boolean mpde, meanPath, medianPath, adaptive;
 

--- a/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/properties/SimulationProperties.java
+++ b/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/properties/SimulationProperties.java
@@ -16,6 +16,8 @@ package edu.utah.ece.async.ibiosim.analysis.properties;
 import java.util.ArrayList;
 import java.util.List;
 
+import edu.utah.ece.async.ibiosim.dataModels.util.observe.CoreObservable;
+
 /**
  * The simulation properties contains information associated with the simulation options.
  * 
@@ -25,8 +27,8 @@ import java.util.List;
  * @version $Rev$
  * @version %I%
  */
-public class SimulationProperties {
-
+public final class SimulationProperties extends CoreObservable
+{
 
   private int         numSteps, run, startIndex;
   private double        initialTime, outputStartTime, minTimeStep, maxTimeStep, printInterval, timeLimit, absError, relError;

--- a/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/properties/VerificationProperties.java
+++ b/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/properties/VerificationProperties.java
@@ -16,6 +16,7 @@ package edu.utah.ece.async.ibiosim.analysis.properties;
 import java.util.ArrayList;
 import java.util.List;
 
+import edu.utah.ece.async.ibiosim.dataModels.util.observe.CoreObservable;
 import edu.utah.ece.async.lema.verification.lpn.properties.AbstractionProperty;
 
 /**
@@ -27,7 +28,7 @@ import edu.utah.ece.async.lema.verification.lpn.properties.AbstractionProperty;
  * @version $Rev$
  * @version %I%
  */
-public class VerificationProperties 
+public final class VerificationProperties extends CoreObservable
 {
 
   private AbstractionProperty absProperty;

--- a/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/simulation/hierarchical/methods/HierarchicalFBASimulator.java
+++ b/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/simulation/hierarchical/methods/HierarchicalFBASimulator.java
@@ -55,6 +55,7 @@ class HierarchicalFBASimulator extends HierarchicalSimulation
 			values.put(parameter.getId(), parameter.getValue());
 		}
 		fba = new FluxBalanceAnalysis(model, 1e-9);
+		this.addObservable(fba);
 	}
 
 	@Override

--- a/conversion/src/main/java/edu/utah/ece/async/ibiosim/conversion/Converter.java
+++ b/conversion/src/main/java/edu/utah/ece/async/ibiosim/conversion/Converter.java
@@ -31,6 +31,7 @@ import org.sbolstandard.core2.SBOLValidationException;
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.parser.BioModel;
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.util.SBMLutilities;
 import edu.utah.ece.async.ibiosim.dataModels.sbol.SBOLUtility;
+import edu.utah.ece.async.ibiosim.dataModels.util.exceptions.BioSimException;
 import edu.utah.ece.async.ibiosim.dataModels.util.exceptions.SBOLException;
 
 /**
@@ -372,8 +373,9 @@ public class Converter {
 						usage();
 					}
 					
-					//SBML file is relative. No external path was given for the input SBML file. 
-					inputSBMLDoc = SBMLutilities.readSBML(fullInputFileName);
+					//SBML file is relative. No external path was given for the input SBML file.
+					
+					inputSBMLDoc = SBMLutilities.readSBML(fullInputFileName, null, null);
 
 					SBML2SBOL.convert_SBML2SBOL(outSBOLDoc, externalSBMLPath, inputSBMLDoc, fullInputFileName, ref_sbolInputFilePath, URIPrefix); 
 
@@ -418,6 +420,10 @@ public class Converter {
 					System.err.println("ERROR: Unable to read or write file");
 					e.printStackTrace();
 				}
+				catch (BioSimException e) {
+				  System.err.println("ERROR: Invalid SBML file");
+          e.printStackTrace();
+	      }
 			} //end of is input is SBML
 			else if(inputIsSBOL)
 			{
@@ -479,6 +485,10 @@ public class Converter {
 					{
 						System.err.println(e.getMessage());
 					}
+					catch (BioSimException e) 
+          {
+            System.err.println(e.getMessage());
+          }
 				}
 			} //end of isSBOL input
 		}//end of is not a directory check

--- a/conversion/src/main/java/edu/utah/ece/async/ibiosim/conversion/SBOL2SBML.java
+++ b/conversion/src/main/java/edu/utah/ece/async/ibiosim/conversion/SBOL2SBML.java
@@ -59,6 +59,7 @@ import edu.utah.ece.async.ibiosim.dataModels.biomodel.parser.BioModel;
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.util.SBMLutilities;
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.util.Utility;
 import edu.utah.ece.async.ibiosim.dataModels.util.GlobalConstants;
+import edu.utah.ece.async.ibiosim.dataModels.util.exceptions.BioSimException;
 
 
 /**
@@ -99,8 +100,9 @@ public class SBOL2SBML {
 	 * @return The list of SBML models converted from SBOL ModuleDefinition. Each of the converted SBML model are stored within iBioSim's BioModel object.
 	 * @throws XMLStreamException - Invalid XML file occurred
 	 * @throws IOException - Unable to read/write file for SBOL2SBML converter.
+	 * @throws BioSimException - if something is wrong with the SBML model.
 	 */
-	public static List<BioModel> generateModel(String projectDirectory, ModuleDefinition moduleDef, SBOLDocument sbolDoc) throws XMLStreamException, IOException {
+	public static List<BioModel> generateModel(String projectDirectory, ModuleDefinition moduleDef, SBOLDocument sbolDoc) throws XMLStreamException, IOException, BioSimException {
 
 		List<BioModel> models = new LinkedList<BioModel>();
 
@@ -318,9 +320,10 @@ public class SBOL2SBML {
 	 * @return
 	 * @throws XMLStreamException - Invalid XML file.
 	 * @throws IOException - Unable to read/write file for SBOL2SBML converter.
+	 * @throws BioSimException - if something is wrong the with SBML model.
 	 */
 	private static List<BioModel> generateSubModel(String projectDirectory, Module subModule, ModuleDefinition moduleDef, SBOLDocument sbolDoc, 
-			BioModel targetModel) throws XMLStreamException, IOException {
+			BioModel targetModel) throws XMLStreamException, IOException, BioSimException {
 		ModuleDefinition subModuleDef = sbolDoc.getModuleDefinition(subModule.getDefinitionURI());
 		//convert each submodules into its own SBML model stored in their own .xml file.
 		List<BioModel> subModels = generateModel(projectDirectory, subModuleDef, sbolDoc);
@@ -1352,6 +1355,10 @@ public class SBOL2SBML {
 				e.printStackTrace();
 			} catch (XMLStreamException e) {
 				e.printStackTrace();
+			}
+			catch(BioSimException e)
+			{
+			  e.printStackTrace();
 			}
 
 		}

--- a/dataModels/src/main/java/edu/utah/ece/async/ibiosim/dataModels/biomodel/network/GeneticNetwork.java
+++ b/dataModels/src/main/java/edu/utah/ece/async/ibiosim/dataModels/biomodel/network/GeneticNetwork.java
@@ -127,7 +127,7 @@ public class GeneticNetwork extends CoreObservable
 	public void buildTemplate(HashMap<String, SpeciesInterface> species,			
 			HashMap<String, Promoter> promoters, String gcm, String filename) throws XMLStreamException, IOException {
 		
-		BioModel file = new BioModel(currentRoot);
+		BioModel file = BioModel.createBioModel(currentRoot, this);
 		file.load(currentRoot+gcm);
 		AbstractPrintVisitor.setGCMFile(file);
 		setSpecies(species);

--- a/dataModels/src/main/java/edu/utah/ece/async/ibiosim/dataModels/biomodel/network/GeneticNetwork.java
+++ b/dataModels/src/main/java/edu/utah/ece/async/ibiosim/dataModels/biomodel/network/GeneticNetwork.java
@@ -54,6 +54,7 @@ import edu.utah.ece.async.ibiosim.dataModels.biomodel.visitor.PrintRepressionBin
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.visitor.PrintSpeciesVisitor;
 import edu.utah.ece.async.ibiosim.dataModels.util.GlobalConstants;
 import edu.utah.ece.async.ibiosim.dataModels.util.Message;
+import edu.utah.ece.async.ibiosim.dataModels.util.exceptions.BioSimException;
 import edu.utah.ece.async.ibiosim.dataModels.util.observe.CoreObservable;
 
 /**
@@ -125,7 +126,7 @@ public class GeneticNetwork extends CoreObservable
 	}
 	
 	public void buildTemplate(HashMap<String, SpeciesInterface> species,			
-			HashMap<String, Promoter> promoters, String gcm, String filename) throws XMLStreamException, IOException {
+			HashMap<String, Promoter> promoters, String gcm, String filename) throws XMLStreamException, IOException, BioSimException {
 		
 		BioModel file = BioModel.createBioModel(currentRoot, this);
 		file.load(currentRoot+gcm);
@@ -275,14 +276,15 @@ public class GeneticNetwork extends CoreObservable
 	 * @return the sbml document
 	 * @throws IOException 
 	 * @throws XMLStreamException 
+	 * @throws BioSimException 
 	 */
-	public SBMLDocument mergeSBML(String filename) throws XMLStreamException, IOException {
+	public SBMLDocument mergeSBML(String filename) throws XMLStreamException, IOException, BioSimException {
 		if (document == null) {
 			if (sbmlDocument.equals("")) {
 				return outputSBML(filename);
 			}
 			
-			SBMLDocument document = SBMLutilities.readSBML(currentRoot + sbmlDocument);
+			SBMLDocument document = SBMLutilities.readSBML(currentRoot + sbmlDocument, this, null);
 			// checkConsistancy(document);
 			currentDocument = document;
 			return outputSBML(filename, document);
@@ -831,7 +833,7 @@ public class GeneticNetwork extends CoreObservable
 		if (!complex.isAbstractable()) {
 			if (!isGenetic(complexId)
 					&& !complex.isDiffusible()
-					&& !SBMLutilities.variableInUse(document, complexId, false, false, true)
+					&& !SBMLutilities.variableInUse(document, complexId, false, true, this, null)
 					&& !SBMLutilities.usedInNonDegradationReaction(document, complexId)) {
 				complex.setAbstractable(true);
 				for (Influence infl : complexMap.get(complexId)) {

--- a/dataModels/src/main/java/edu/utah/ece/async/ibiosim/dataModels/biomodel/parser/BioModel.java
+++ b/dataModels/src/main/java/edu/utah/ece/async/ibiosim/dataModels/biomodel/parser/BioModel.java
@@ -95,6 +95,8 @@ import edu.utah.ece.async.ibiosim.dataModels.util.GlobalConstants;
 import edu.utah.ece.async.ibiosim.dataModels.util.Message;
 import edu.utah.ece.async.ibiosim.dataModels.util.SEDMLutilities;
 import edu.utah.ece.async.ibiosim.dataModels.util.exceptions.BioSimException;
+import edu.utah.ece.async.ibiosim.dataModels.util.observe.BioObservable;
+import edu.utah.ece.async.ibiosim.dataModels.util.observe.BioObserver;
 import edu.utah.ece.async.ibiosim.dataModels.util.observe.CoreObservable;
 
 
@@ -110,9 +112,33 @@ public class BioModel extends CoreObservable{
 
 	private String filename = null;
 
-	private Message message = new Message();
+	private final Message message = new Message();
 
 	private GridTable gridTable;
+	
+	public static BioModel createBioModel(String path, BioObservable observable)
+	{
+	  BioModel biomodel = new BioModel(path);
+	  
+	  if(observable != null)
+	  {
+	    biomodel.addObservable(observable);
+	  }
+	  
+	  return biomodel;
+	}
+	
+	public static BioModel createBioModel(String path, BioObserver observer)
+  {
+    BioModel biomodel = new BioModel(path);
+    
+    if(observer != null)
+    {
+      biomodel.addObserver(observer);
+    }
+    
+    return biomodel;
+  }
 	
 	public BioModel(String path) {
 		this.path = path;
@@ -5377,7 +5403,7 @@ public class BioModel extends CoreObservable{
 		//if (!this.isGridEnabled()) {
 		for (int i = 0; i < sbmlCompModel.getListOfSubmodels().size(); i++) {
 			Submodel submodel = sbmlCompModel.getListOfSubmodels().get(i);
-			BioModel subBioModel = new BioModel(path);		
+			BioModel subBioModel =  BioModel.createBioModel(path, this);	
 			String extModelFile = sbmlComp.getListOfExternalModelDefinitions().get(submodel.getModelRef())
 					.getSource().replace("file://","").replace("file:","").replace(".gcm",".xml");
 			subBioModel.load(path + File.separator + extModelFile);
@@ -5826,7 +5852,7 @@ public class BioModel extends CoreObservable{
 			document.enablePackage(org.sbml.libsbml.CompExtension.getXmlnsL3V1V1(), "comp", !removeComp);
 			org.sbml.libsbml.SBMLWriter writer = new org.sbml.libsbml.SBMLWriter();
 			writer.writeSBMLToFile(document, tempFile);
-			BioModel bioModel = new BioModel(path);
+			BioModel bioModel = BioModel.createBioModel(path, this);
 			bioModel.load(tempFile);
 			new File(tempFile).delete();
 			SBMLDocument doc = bioModel.getSBMLDocument();
@@ -5855,7 +5881,7 @@ public class BioModel extends CoreObservable{
 		String tempFile = filename.replace(".gcm","").replace(".xml","")+"_temp.xml";
 		save(tempFile);
 
-		BioModel model = new BioModel(path);
+		BioModel model = BioModel.createBioModel(path, this);
 		model.load(tempFile);
 		model.getSBMLDocument().getModel().unsetExtension(LayoutConstants.namespaceURI);
 		model.getSBMLDocument().disablePackage(LayoutConstants.namespaceURI);
@@ -5902,7 +5928,7 @@ public class BioModel extends CoreObservable{
 
 		// loop through the list of submodels
 		for (String subModelId : comps) {
-			BioModel subModel = new BioModel(path);		
+			BioModel subModel =  BioModel.createBioModel(path, this);	
 			String extModelFile = model.getExtModelFileName(subModelId);
 			subModel.load(path + File.separator + extModelFile);
 			ArrayList<String> modelListCopy = copyArray(modelList);
@@ -5975,7 +6001,7 @@ public class BioModel extends CoreObservable{
 
 		// loop through the list of submodels
 		for (String subModelId : comps) {
-			BioModel subModel = new BioModel(path);		
+			BioModel subModel = BioModel.createBioModel(path, this);	
 			String extModelFile = getExtModelFileName(subModelId);
 			subModel.load(path + File.separator + extModelFile);
 			ArrayList<String> modelListCopy = copyArray(modelList);
@@ -6030,7 +6056,7 @@ public class BioModel extends CoreObservable{
 		}
 		
 		for (String s : comps) {
-			BioModel subModel = new BioModel(path);
+			BioModel subModel = BioModel.createBioModel(path, this);
 			String extModel = model.getSBMLComp().getListOfExternalModelDefinitions().get(model.getSBMLCompModel().getListOfSubmodels().get(s)
 					.getModelRef()).getSource().replace("file://","").replace("file:","").replace(".gcm",".xml");
 			subModel.load(path + File.separator + extModel);
@@ -6687,7 +6713,7 @@ public class BioModel extends CoreObservable{
 	 */
 	public boolean getGridEnabledFromFile(String filename) throws XMLStreamException, IOException {
 		
-		BioModel subModel = new BioModel(path);
+		BioModel subModel =  BioModel.createBioModel(path, this);
 		subModel.load(filename);
 		if ((subModel.gridTable.getNumRows() > 0) || (subModel.gridTable.getNumCols() > 0)) return true;
 		return false;

--- a/dataModels/src/main/java/edu/utah/ece/async/ibiosim/dataModels/biomodel/parser/BioModel.java
+++ b/dataModels/src/main/java/edu/utah/ece/async/ibiosim/dataModels/biomodel/parser/BioModel.java
@@ -2186,8 +2186,9 @@ public class BioModel extends CoreObservable{
 	 * @param filename
 	 * @throws IOException 
 	 * @throws XMLStreamException 
+	 * @throws BioSimException 
 	 */
-	public void save(String filename) throws XMLStreamException, IOException {		
+	public void save(String filename) throws XMLStreamException, IOException, BioSimException {		
 		updatePorts();
 		setGridSize(gridTable.getNumRows(),gridTable.getNumCols());
 		setLayoutSize();
@@ -2209,7 +2210,7 @@ public class BioModel extends CoreObservable{
 		}
 	}
 
-	public boolean load(String filename) throws XMLStreamException, IOException {
+	public boolean load(String filename) throws XMLStreamException, IOException, BioSimException {
 		//gcm2sbml.load(filename);
 		this.filename = filename;
 		String[] splitPath = GlobalConstants.splitPath(filename);
@@ -2728,7 +2729,7 @@ public class BioModel extends CoreObservable{
 
 	
 	public void removeReaction(String id) {
-		if (SBMLutilities.variableInUse(sbml, id, false, true, true)) return;
+		if (SBMLutilities.variableInUse(sbml, id, false, true, this, null)) return;
 //		Reaction tempReaction = sbml.getModel().getReaction(id);
 //
 //		ListOf<Reaction> r = sbml.getModel().getListOfReactions();
@@ -5383,7 +5384,7 @@ public class BioModel extends CoreObservable{
 		return false;
 	}
 	
-	private void updatePorts() throws XMLStreamException, IOException {
+	private void updatePorts() throws XMLStreamException, IOException, BioSimException {
 		int j = 0;
 		while (j < sbmlCompModel.getPortCount()) {
 			Port port = sbmlCompModel.getListOfPorts().get(j);
@@ -5543,11 +5544,11 @@ public class BioModel extends CoreObservable{
 		}
 	}
 
-	private boolean loadSBMLFile(String sbmlFile) throws XMLStreamException, IOException {
+	private boolean loadSBMLFile(String sbmlFile) throws XMLStreamException, IOException, BioSimException {
 		boolean successful = true;
 		if (!sbmlFile.equals("")) {
 			if (new File(path + File.separator + sbmlFile).exists()) {
-				sbml = SBMLutilities.readSBML(path + File.separator + sbmlFile);
+				sbml = SBMLutilities.readSBML(path + File.separator + sbmlFile, this, null);
 				createLayoutPlugin();
 				createCompPlugin();
 				createFBCPlugin();
@@ -5576,14 +5577,14 @@ public class BioModel extends CoreObservable{
 
 	
 	public void recurseExportSingleFile(ArrayList<String> comps,CompModelPlugin subCompModel,CompSBMLDocumentPlugin subComp,
-				CompSBMLDocumentPlugin documentComp) throws XMLStreamException, IOException {
+				CompSBMLDocumentPlugin documentComp) throws XMLStreamException, IOException, BioSimException {
 		for (int i = 0; i < subCompModel.getListOfSubmodels().size(); i++) {
 			String subModelId = subCompModel.getListOfSubmodels().get(i).getId();
 			String extModel = subComp.getListOfExternalModelDefinitions().get(subCompModel.getListOfSubmodels().get(subModelId)
 					.getModelRef()).getSource().replace("file://","").replace("file:","").replace(".gcm",".xml");
 			if (!comps.contains(extModel)) {
 				comps.add(extModel);
-				SBMLDocument subDocument = SBMLutilities.readSBML(path + File.separator + extModel);
+				SBMLDocument subDocument = SBMLutilities.readSBML(path + File.separator + extModel, this, null);
 				CompModelPlugin subDocumentCompModel = SBMLutilities.getCompModelPlugin(subDocument.getModel());
 				ModelDefinition md = new ModelDefinition(subDocument.getModel());
 				
@@ -5616,7 +5617,7 @@ public class BioModel extends CoreObservable{
 		}
 	}
 	
-	public void exportSingleFile(String exportFile) throws XMLStreamException, IOException {
+	public void exportSingleFile(String exportFile) throws XMLStreamException, IOException, BioSimException {
 		SBMLDocument document = createSingleDocument();
 		SBMLWriter writer = new SBMLWriter();
 		try {
@@ -5631,7 +5632,7 @@ public class BioModel extends CoreObservable{
 		}
 	}
 	
-	public SBMLDocument createSingleDocument() throws XMLStreamException, IOException {
+	public SBMLDocument createSingleDocument() throws XMLStreamException, IOException, BioSimException {
 		ArrayList<String> comps = new ArrayList<String>();
 		SBMLDocument document = new SBMLDocument(GlobalConstants.SBML_LEVEL, GlobalConstants.SBML_VERSION);
 		Model model = new Model(sbml.getModel());
@@ -5670,7 +5671,7 @@ public class BioModel extends CoreObservable{
 						.getModelRef()).getSource().replace("file://","").replace("file:","").replace(".gcm",".xml");
 				if (!comps.contains(extModel)) {
 					comps.add(extModel);
-					SBMLDocument subDocument = SBMLutilities.readSBML(path + File.separator + extModel);
+					SBMLDocument subDocument = SBMLutilities.readSBML(path + File.separator + extModel, this, null);
 					CompModelPlugin subDocumentCompModel = SBMLutilities.getCompModelPlugin(subDocument.getModel());
 					String id = subDocument.getModel().getId();
 					// TODO: hack to avoid jsbml scope bug
@@ -5711,7 +5712,7 @@ public class BioModel extends CoreObservable{
 		return document;
 	}
 	
-	private void expandListOfSubmodels(org.sbml.libsbml.CompModelPlugin docCompModel, org.sbml.libsbml.SBMLDocument sbml) throws XMLStreamException, IOException {
+	private void expandListOfSubmodels(org.sbml.libsbml.CompModelPlugin docCompModel, org.sbml.libsbml.SBMLDocument sbml) throws XMLStreamException, IOException, BioSimException {
 		if (this.getGridEnabledFromFile(filename.replace(".gcm",".xml"))) {
 			
 			//look through the location parameter arrays
@@ -5736,7 +5737,7 @@ public class BioModel extends CoreObservable{
 		}
 	}
 	
-	private ArrayList<String> getListOfSubmodels() throws XMLStreamException, IOException {
+	private ArrayList<String> getListOfSubmodels() throws XMLStreamException, IOException, BioSimException {
 		ArrayList<String> comps = new ArrayList<String>();
 
 		if (this.getGridEnabledFromFile(filename.replace(".gcm",".xml"))) {
@@ -5765,7 +5766,7 @@ public class BioModel extends CoreObservable{
 		return comps;
 	}
 	
-	private String getExtModelFileName(String s) throws XMLStreamException, IOException {
+	private String getExtModelFileName(String s) throws XMLStreamException, IOException, BioSimException {
 		
 		String extModel;
 		String componentModelRef = "";
@@ -5861,7 +5862,7 @@ public class BioModel extends CoreObservable{
 		throw new Exception("libsbml not found.  Unable to flatten model.");
 	}
 		
-	public SBMLDocument flattenModel(boolean removeComp) throws XMLStreamException, IOException {
+	public SBMLDocument flattenModel(boolean removeComp) throws XMLStreamException, IOException, BioSimException {
 		Preferences biosimrc = Preferences.userRoot();
 		if (biosimrc.get("biosim.general.flatten", "").equals("libsbml")) {
 			//String tempFile = filename.replace(".gcm","").replace(".xml","")+"_temp.xml";
@@ -5979,7 +5980,7 @@ public class BioModel extends CoreObservable{
 	}
 
 	// TODO: check if this is up-to-date
-	public SBMLDocument flattenBioModel() throws XMLStreamException, IOException {
+	public SBMLDocument flattenBioModel() throws XMLStreamException, IOException, BioSimException {
 		Preferences biosimrc = Preferences.userRoot();
 		if (biosimrc.get("biosim.general.flatten", "").equals("libsbml")) {
 			SBMLDocument result = null;
@@ -6035,7 +6036,7 @@ public class BioModel extends CoreObservable{
 		return this.getSBMLDocument();
 	}
 	
-	private BioModel flattenModelRecurse(BioModel model, ArrayList<String> modelList) throws XMLStreamException, IOException {
+	private BioModel flattenModelRecurse(BioModel model, ArrayList<String> modelList) throws XMLStreamException, IOException, BioSimException {
 		ArrayList<String> comps = new ArrayList<String>();
 		
 		model.getSBMLDocument().getModel().unsetExtension(LayoutConstants.namespaceURI);
@@ -6710,8 +6711,9 @@ public class BioModel extends CoreObservable{
 	 * @return
 	 * @throws IOException 
 	 * @throws XMLStreamException 
+	 * @throws BioSimException 
 	 */
-	public boolean getGridEnabledFromFile(String filename) throws XMLStreamException, IOException {
+	public boolean getGridEnabledFromFile(String filename) throws XMLStreamException, IOException, BioSimException {
 		
 		BioModel subModel =  BioModel.createBioModel(path, this);
 		subModel.load(filename);

--- a/dataModels/src/main/java/edu/utah/ece/async/ibiosim/dataModels/biomodel/parser/GCM2SBML.java
+++ b/dataModels/src/main/java/edu/utah/ece/async/ibiosim/dataModels/biomodel/parser/GCM2SBML.java
@@ -34,6 +34,8 @@ import org.sbml.jsbml.ext.comp.Port;
 
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.util.SBMLutilities;
 import edu.utah.ece.async.ibiosim.dataModels.util.GlobalConstants;
+import edu.utah.ece.async.ibiosim.dataModels.util.exceptions.BioSimException;
+import edu.utah.ece.async.ibiosim.dataModels.util.observe.CoreObservable;
 
 /**
  * 
@@ -43,7 +45,8 @@ import edu.utah.ece.async.ibiosim.dataModels.util.GlobalConstants;
  * @author <a href="http://www.async.ece.utah.edu/ibiosim#Credits"> iBioSim Contributors </a>
  * @version %I%
  */
-public class GCM2SBML {
+public class GCM2SBML extends CoreObservable
+{
 	
 	public GCM2SBML(BioModel gcm) {
 		species = new HashMap<String, Properties>();
@@ -741,8 +744,9 @@ public class GCM2SBML {
 	 * @return
 	 * @throws IOException 
 	 * @throws XMLStreamException 
+	 * @throws BioSimException 
 	 */
-	public void convertGCM2SBML(String root, String fileName) throws XMLStreamException, IOException {
+	public void convertGCM2SBML(String root, String fileName) throws XMLStreamException, IOException, BioSimException {
 		String filename = root + File.separator + fileName;
 		int condCnt = 0;
 		for (String s : conditions) {
@@ -852,7 +856,7 @@ public class GCM2SBML {
 			bioModel.createComponentFromGCM(s,components.get(s));
 		}
 		if (sbmlFile!=null && !sbmlFile.equals("")) {
-			SBMLDocument document = SBMLutilities.readSBML(root + File.separator + sbmlFile);
+			SBMLDocument document = SBMLutilities.readSBML(root + File.separator + sbmlFile, this, null);
 			if (document!=null) {
 				Model model = document.getModel();
 				Model modelNew = bioModel.getSBMLDocument().getModel();

--- a/dataModels/src/main/java/edu/utah/ece/async/ibiosim/dataModels/biomodel/parser/GCMParser.java
+++ b/dataModels/src/main/java/edu/utah/ece/async/ibiosim/dataModels/biomodel/parser/GCMParser.java
@@ -38,6 +38,7 @@ import edu.utah.ece.async.ibiosim.dataModels.biomodel.network.Promoter;
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.network.SpasticSpecies;
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.network.SpeciesInterface;
 import edu.utah.ece.async.ibiosim.dataModels.util.GlobalConstants;
+import edu.utah.ece.async.ibiosim.dataModels.util.exceptions.BioSimException;
 import edu.utah.ece.async.ibiosim.dataModels.util.observe.CoreObservable;
 
 /**
@@ -50,7 +51,7 @@ import edu.utah.ece.async.ibiosim.dataModels.util.observe.CoreObservable;
  */
 public class GCMParser extends CoreObservable{
 
-	public GCMParser(String filename) throws XMLStreamException, IOException {
+	public GCMParser(String filename) throws XMLStreamException, IOException, BioSimException {
 		//this.debug = debug;
 		biomodel = BioModel.createBioModel(filename.substring(0, filename.length()
       - GlobalConstants.getFilename(filename).length()), this);

--- a/dataModels/src/main/java/edu/utah/ece/async/ibiosim/dataModels/biomodel/parser/GCMParser.java
+++ b/dataModels/src/main/java/edu/utah/ece/async/ibiosim/dataModels/biomodel/parser/GCMParser.java
@@ -38,6 +38,7 @@ import edu.utah.ece.async.ibiosim.dataModels.biomodel.network.Promoter;
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.network.SpasticSpecies;
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.network.SpeciesInterface;
 import edu.utah.ece.async.ibiosim.dataModels.util.GlobalConstants;
+import edu.utah.ece.async.ibiosim.dataModels.util.observe.CoreObservable;
 
 /**
  * This class parses a genetic circuit model.
@@ -47,12 +48,12 @@ import edu.utah.ece.async.ibiosim.dataModels.util.GlobalConstants;
  * @author <a href="http://www.async.ece.utah.edu/ibiosim#Credits"> iBioSim Contributors </a>
  * @version %I%
  */
-public class GCMParser {
+public class GCMParser extends CoreObservable{
 
 	public GCMParser(String filename) throws XMLStreamException, IOException {
 		//this.debug = debug;
-		biomodel = new BioModel(filename.substring(0, filename.length()
-				- GlobalConstants.getFilename(filename).length()));
+		biomodel = BioModel.createBioModel(filename.substring(0, filename.length()
+      - GlobalConstants.getFilename(filename).length()), this);
 		biomodel.load(filename);
 		
 		data = new StringBuffer();

--- a/dataModels/src/main/java/edu/utah/ece/async/ibiosim/dataModels/biomodel/util/SBMLutilities.java
+++ b/dataModels/src/main/java/edu/utah/ece/async/ibiosim/dataModels/biomodel/util/SBMLutilities.java
@@ -33,7 +33,6 @@ import javax.xml.stream.XMLStreamException;
 
 import odk.lang.FastMath;
 
-import org.jlibsedml.SEDMLDocument;
 import org.sbml.jsbml.ASTNode;
 import org.sbml.jsbml.AbstractNamedSBase;
 import org.sbml.jsbml.AbstractSBase;
@@ -5627,19 +5626,6 @@ public class SBMLutilities extends CoreObservable
 				}
 			}
 		}
-//		if (display)
-//		{
-//			messageArea.setLineWrap(true);
-//			messageArea.setEditable(false);
-//			messageArea.setSelectionStart(0);
-//			messageArea.setSelectionEnd(0);
-//			JScrollPane scroll = new JScrollPane();
-//			scroll.setMinimumSize(new java.awt.Dimension(600, 600));
-//			scroll.setPreferredSize(new java.awt.Dimension(600, 600));
-//			scroll.setViewportView(messageArea);
-//			JOptionPane.showMessageDialog(Gui.frame, scroll, "SBML Model Completeness Errors", JOptionPane.ERROR_MESSAGE);
-//
-//		}
 	}
 
 	// TODO: should weave in better with existing conversion
@@ -5783,7 +5769,7 @@ public class SBMLutilities extends CoreObservable
 				}
 				
 				Message message = new Message();
-				message.setDialog("SBML Conversion Errors and Warnings", msg);
+				message.setErrorDialog("SBML Conversion Errors and Warnings", msg);
 				
 				if(observable != null)
 				{
@@ -5793,8 +5779,6 @@ public class SBMLutilities extends CoreObservable
 				{
 				  observer.update(message);
 				}
-				observable.notifyObservers(message);
-				message.setConsole(msg);
 			}
 			convertToL3(doc);
 			doc.setLevelAndVersion(GlobalConstants.SBML_LEVEL, GlobalConstants.SBML_VERSION, false);

--- a/dataModels/src/main/java/edu/utah/ece/async/ibiosim/dataModels/biomodel/util/SBMLutilities.java
+++ b/dataModels/src/main/java/edu/utah/ece/async/ibiosim/dataModels/biomodel/util/SBMLutilities.java
@@ -2633,7 +2633,7 @@ public class SBMLutilities extends CoreObservable
 			}
 			
 			Message message = new Message();
-      message.setErrorDialog("Unable To Remove Variable", msg);
+      message.setScrollableErrorDialog("Unable To Remove Variable", msg);
       if(observable != null)
       {
         observable.notifyObservers(message);
@@ -5769,7 +5769,7 @@ public class SBMLutilities extends CoreObservable
 				}
 				
 				Message message = new Message();
-				message.setErrorDialog("SBML Conversion Errors and Warnings", msg);
+				message.setScrollableErrorDialog("SBML Conversion Errors and Warnings", msg);
 				
 				if(observable != null)
 				{

--- a/dataModels/src/main/java/edu/utah/ece/async/ibiosim/dataModels/biomodel/util/SBMLutilities.java
+++ b/dataModels/src/main/java/edu/utah/ece/async/ibiosim/dataModels/biomodel/util/SBMLutilities.java
@@ -108,6 +108,9 @@ import edu.utah.ece.async.ibiosim.dataModels.util.Executables;
 import edu.utah.ece.async.ibiosim.dataModels.util.GlobalConstants;
 import edu.utah.ece.async.ibiosim.dataModels.util.Message;
 import edu.utah.ece.async.ibiosim.dataModels.util.exceptions.BioSimException;
+import edu.utah.ece.async.ibiosim.dataModels.util.observe.BioObservable;
+import edu.utah.ece.async.ibiosim.dataModels.util.observe.BioObserver;
+import edu.utah.ece.async.ibiosim.dataModels.util.observe.CoreObservable;
 import flanagan.math.Fmath;
 import flanagan.math.PsRandom;
 
@@ -124,11 +127,10 @@ import flanagan.math.PsRandom;
  * @author <a href="http://www.async.ece.utah.edu/ibiosim#Credits"> iBioSim Contributors </a>
  * @version %I%
  */
-public class SBMLutilities
+public class SBMLutilities extends CoreObservable
 {
 
 	public static final SystemsBiologyOntology sbo = new SystemsBiologyOntology();
-	public static final Message message = new Message();
 	
 	/**
 	 * The user has the option to :
@@ -145,9 +147,10 @@ public class SBMLutilities
 	 * @throws XMLStreamException Invalid XML file
 	 * @throws SBMLException SBML Exception occurred when exporting BioModels to an SBML file
 	 * @throws IOException Unable to write file to SBML.
+	 * @throws BioSimException - if sbml model is invalid.
 	 */
 	public static void exportSBMLModels(List<BioModel> models, String outputDir, String outputFileName, 
-			boolean noOutput, boolean sbmlOut, boolean singleSBMLOutput) throws SBMLException, XMLStreamException, IOException
+			boolean noOutput, boolean sbmlOut, boolean singleSBMLOutput) throws SBMLException, XMLStreamException, IOException, BioSimException
 	{
 		// Note: Since SBOL2SBML converter encase the result of SBML model in BioModels, the last biomodel 
 		// given from the converter is the top level model. All submodels belonging to the top level models are nested in side this last biomodel
@@ -213,8 +216,9 @@ public class SBMLutilities
 	 * @param outputDir - The output directory to store the SBML files
 	 * @throws IOException  Unable to write file to SBML.
 	 * @throws XMLStreamException Invalid XML file
+	 * @throws BioSimException - if sbml model is invalid.
 	 */
-	public static ArrayList<String> exportMultSBMLFile(List<BioModel> models, String outputDir) throws XMLStreamException, IOException
+	public static ArrayList<String> exportMultSBMLFile(List<BioModel> models, String outputDir) throws XMLStreamException, IOException, BioSimException
 	{
 		ArrayList<String> submodels = new ArrayList<String>();
 		//Multiple SBML output
@@ -772,189 +776,189 @@ public class SBMLutilities
 	{
 		if (document.getModel().getFunctionDefinition("uniform") != null)
 		{
-			if (!functionInUse(document, "uniform", false, false, true))
+			if (!functionInUse(document, "uniform", false, true, null, null))
 			{
 				document.getModel().removeFunctionDefinition("uniform");
 			}
 		}
 		if (document.getModel().getFunctionDefinition("normal") != null)
 		{
-			if (!functionInUse(document, "normal", false, false, true))
+			if (!functionInUse(document, "normal", false, true, null, null))
 			{
 				document.getModel().removeFunctionDefinition("normal");
 			}
 		}
 		if (document.getModel().getFunctionDefinition("exponential") != null)
 		{
-			if (!functionInUse(document, "exponential", false, false, true))
+			if (!functionInUse(document, "exponential", false, true, null, null))
 			{
 				document.getModel().removeFunctionDefinition("exponential");
 			}
 		}
 		if (document.getModel().getFunctionDefinition("gamma") != null)
 		{
-			if (!functionInUse(document, "gamma", false, false, true))
+			if (!functionInUse(document, "gamma", false, true, null, null))
 			{
 				document.getModel().removeFunctionDefinition("gamma");
 			}
 		}
 		if (document.getModel().getFunctionDefinition("lognormal") != null)
 		{
-			if (!functionInUse(document, "lognormal", false, false, true))
+			if (!functionInUse(document, "lognormal", false, true, null, null))
 			{
 				document.getModel().removeFunctionDefinition("lognormal");
 			}
 		}
 		if (document.getModel().getFunctionDefinition("chisq") != null)
 		{
-			if (!functionInUse(document, "chisq", false, false, true))
+			if (!functionInUse(document, "chisq", false, true, null, null))
 			{
 				document.getModel().removeFunctionDefinition("chisq");
 			}
 		}
 		if (document.getModel().getFunctionDefinition("laplace") != null)
 		{
-			if (!functionInUse(document, "laplace", false, false, true))
+			if (!functionInUse(document, "laplace", false, true, null, null))
 			{
 				document.getModel().removeFunctionDefinition("laplace");
 			}
 		}
 		if (document.getModel().getFunctionDefinition("cauchy") != null)
 		{
-			if (!functionInUse(document, "cauchy", false, false, true))
+			if (!functionInUse(document, "cauchy", false, true, null, null))
 			{
 				document.getModel().removeFunctionDefinition("cauchy");
 			}
 		}
 		if (document.getModel().getFunctionDefinition("rayleigh") != null)
 		{
-			if (!functionInUse(document, "rayleigh", false, false, true))
+			if (!functionInUse(document, "rayleigh", false, true, null, null))
 			{
 				document.getModel().removeFunctionDefinition("rayleigh");
 			}
 		}
 		if (document.getModel().getFunctionDefinition("poisson") != null)
 		{
-			if (!functionInUse(document, "poisson", false, false, true))
+			if (!functionInUse(document, "poisson", false, true, null, null))
 			{
 				document.getModel().removeFunctionDefinition("poisson");
 			}
 		}
 		if (document.getModel().getFunctionDefinition("binomial") != null)
 		{
-			if (!functionInUse(document, "binomial", false, false, true))
+			if (!functionInUse(document, "binomial", false, true, null, null))
 			{
 				document.getModel().removeFunctionDefinition("binomial");
 			}
 		}
 		if (document.getModel().getFunctionDefinition("bernoulli") != null)
 		{
-			if (!functionInUse(document, "bernoulli", false, false, true))
+			if (!functionInUse(document, "bernoulli", false, true, null, null))
 			{
 				document.getModel().removeFunctionDefinition("bernoulli");
 			}
 		}
 		if (document.getModel().getFunctionDefinition("St") != null)
 		{
-			if (!functionInUse(document, "St", false, false, true))
+			if (!functionInUse(document, "St", false, true, null, null))
 			{
 				document.getModel().removeFunctionDefinition("St");
 			}
 		}
 		if (document.getModel().getFunctionDefinition("PSt") != null)
 		{
-			if (!functionInUse(document, "PSt", false, false, true))
+			if (!functionInUse(document, "PSt", false, true, null, null))
 			{
 				document.getModel().removeFunctionDefinition("PSt");
 			}
 		}
 		if (document.getModel().getFunctionDefinition("PG") != null)
 		{
-			if (!functionInUse(document, "PG", false, false, true))
+			if (!functionInUse(document, "PG", false, true, null, null))
 			{
 				document.getModel().removeFunctionDefinition("PG");
 			}
 		}
 		if (document.getModel().getFunctionDefinition("PF") != null)
 		{
-			if (!functionInUse(document, "PF", false, false, true))
+			if (!functionInUse(document, "PF", false, true, null, null))
 			{
 				document.getModel().removeFunctionDefinition("PF");
 			}
 		}
 		if (document.getModel().getFunctionDefinition("PU") != null)
 		{
-			if (!functionInUse(document, "PU", false, false, true))
+			if (!functionInUse(document, "PU", false, true, null, null))
 			{
 				document.getModel().removeFunctionDefinition("PU");
 			}
 		}
 		if (document.getModel().getFunctionDefinition("G") != null)
 		{
-			if (!functionInUse(document, "G", false, false, true))
+			if (!functionInUse(document, "G", false, true, null, null))
 			{
 				document.getModel().removeFunctionDefinition("G");
 			}
 		}
 		if (document.getModel().getFunctionDefinition("F") != null)
 		{
-			if (!functionInUse(document, "F", false, false, true))
+			if (!functionInUse(document, "F", false, true, null, null))
 			{
 				document.getModel().removeFunctionDefinition("F");
 			}
 		}
 		if (document.getModel().getFunctionDefinition("U") != null)
 		{
-			if (!functionInUse(document, "U", false, false, true))
+			if (!functionInUse(document, "U", false, true, null, null))
 			{
 				document.getModel().removeFunctionDefinition("U");
 			}
 		}
 		if (document.getModel().getFunctionDefinition("rate") != null)
 		{
-			if (!functionInUse(document, "rate", false, false, true))
+			if (!functionInUse(document, "rate", false, true, null, null))
 			{
 				document.getModel().removeFunctionDefinition("rate");
 			}
 		}
 		if (document.getModel().getFunctionDefinition("mod") != null)
 		{
-			if (!functionInUse(document, "mod", false, false, true))
+			if (!functionInUse(document, "mod", false, true, null, null))
 			{
 				document.getModel().removeFunctionDefinition("mod");
 			}
 		}
 		if (document.getModel().getFunctionDefinition("BIT") != null)
 		{
-			if (!functionInUse(document, "BIT", false, false, true))
+			if (!functionInUse(document, "BIT", false, true, null, null))
 			{
 				document.getModel().removeFunctionDefinition("BIT");
 			}
 		}
 		if (document.getModel().getFunctionDefinition("BITOR") != null)
 		{
-			if (!functionInUse(document, "BITOR", false, false, true))
+			if (!functionInUse(document, "BITOR", false, true, null, null))
 			{
 				document.getModel().removeFunctionDefinition("BITOR");
 			}
 		}
 		if (document.getModel().getFunctionDefinition("BITXOR") != null)
 		{
-			if (!functionInUse(document, "BITXOR", false, false, true))
+			if (!functionInUse(document, "BITXOR", false, true, null, null))
 			{
 				document.getModel().removeFunctionDefinition("BITXOR");
 			}
 		}
 		if (document.getModel().getFunctionDefinition("BITNOT") != null)
 		{
-			if (!functionInUse(document, "BITNOT", false, false, true))
+			if (!functionInUse(document, "BITNOT", false, true, null, null))
 			{
 				document.getModel().removeFunctionDefinition("BITNOT");
 			}
 		}
 		if (document.getModel().getFunctionDefinition("BITAND") != null)
 		{
-			if (!functionInUse(document, "BITAND", false, false, true))
+			if (!functionInUse(document, "BITAND", false, true, null, null))
 			{
 				document.getModel().removeFunctionDefinition("BITAND");
 			}
@@ -2124,14 +2128,15 @@ public class SBMLutilities
 	 * @param document
 	 * @param id
 	 * @param zeroDim
-	 * @param displayMessage
 	 * @param checkReactions
+	 * @param observable TODO
+	 * @param observer TODO
 	 * @return
 	 */
 	
-	public static boolean functionInUse(SBMLDocument document, String id, boolean zeroDim, boolean displayMessage, boolean checkReactions)
+	public static boolean functionInUse(SBMLDocument document, String id, boolean zeroDim, boolean checkReactions, BioObservable observable, BioObserver observer)
 	{
-		if (variableInUse(document,id,zeroDim,displayMessage,checkReactions)) {
+		if (variableInUse(document,id,zeroDim,checkReactions, observable, observer)) {
 			return true;
 		}
 		Model model = document.getModel();
@@ -2154,7 +2159,7 @@ public class SBMLutilities
 	/**
 	 * Check if a variable is in use.
 	 */
-	public static boolean variableInUse(SBMLDocument document, String id, boolean zeroDim, boolean displayMessage, boolean checkReactions)
+	public static boolean variableInUse(SBMLDocument document, String id, boolean zeroDim, boolean checkReactions, BioObservable observable, BioObserver observer)
 	{
 		Model model = document.getModel();
 		boolean inUse = false;
@@ -2562,73 +2567,85 @@ public class SBMLutilities
 					events += evs[i] + "\n";
 				}
 			}
-			String message;
+			String msg;
 			if (zeroDim)
 			{
-				message = "Unable to change compartment to 0-dimensions.";
+				msg = "Unable to change compartment to 0-dimensions.";
 			}
 			else
 			{
-				message = "Unable to remove the selected variable.";
+				msg = "Unable to remove the selected variable.";
 			}
 			if (usedInModelConversionFactor)
 			{
-				message += "\n\nIt is used as the model conversion factor.\n";
+				msg += "\n\nIt is used as the model conversion factor.\n";
 			}
 			if (speciesUsing.size() != 0)
 			{
-				message += "\n\nIt is used as a conversion factor in the following species:\n" + speciesConvFac;
+				msg += "\n\nIt is used as a conversion factor in the following species:\n" + speciesConvFac;
 			}
 			if (reactantsUsing.size() != 0)
 			{
-				message += "\n\nIt is used as a reactant in the following reactions:\n" + reactants;
+				msg += "\n\nIt is used as a reactant in the following reactions:\n" + reactants;
 			}
 			if (productsUsing.size() != 0)
 			{
-				message += "\n\nIt is used as a product in the following reactions:\n" + products;
+				msg += "\n\nIt is used as a product in the following reactions:\n" + products;
 			}
 			if (modifiersUsing.size() != 0)
 			{
-				message += "\n\nIt is used as a modifier in the following reactions:\n" + modifiers;
+				msg += "\n\nIt is used as a modifier in the following reactions:\n" + modifiers;
 			}
 			if (kineticLawsUsing.size() != 0)
 			{
-				message += "\n\nIt is used in the kinetic law in the following reactions:\n" + kineticLaws;
+				msg += "\n\nIt is used in the kinetic law in the following reactions:\n" + kineticLaws;
 			}
 			if (fluxboundsUsing.size() != 0)
 			{
-				message += "\n\nIt is used in the flux bounds in the following reactions:\n" + fluxbounds;
+				msg += "\n\nIt is used in the flux bounds in the following reactions:\n" + fluxbounds;
 			}
 			if (defaultParametersNeeded.size() != 0)
 			{
-				message += "\n\nDefault parameter is needed by the following reactions:\n" + defaults;
+				msg += "\n\nDefault parameter is needed by the following reactions:\n" + defaults;
 			}
 			if (stoicMathUsing.size() != 0)
 			{
-				message += "\n\nIt is used in the stoichiometry math for the following reaction/species:\n" + stoicMath;
+				msg += "\n\nIt is used in the stoichiometry math for the following reaction/species:\n" + stoicMath;
 			}
 			if (initsUsing.size() != 0)
 			{
-				message += "\n\nIt is used in the following initial assignments:\n" + initAssigns;
+				msg += "\n\nIt is used in the following initial assignments:\n" + initAssigns;
 			}
 			if (rulesUsing.size() != 0)
 			{
-				message += "\n\nIt is used in the following rules:\n" + rules;
+				msg += "\n\nIt is used in the following rules:\n" + rules;
 			}
 			if (constraintsUsing.size() != 0)
 			{
-				message += "\n\nIt is used in the following constraints:\n" + constraints;
+				msg += "\n\nIt is used in the following constraints:\n" + constraints;
 			}
 			if (eventsUsing.size() != 0)
 			{
-				message += "\n\nIt is used in the following events:\n" + events;
+				msg += "\n\nIt is used in the following events:\n" + events;
 			}
 			if (fluxObjUsing.size() != 0)
 			{
-				message += "\n\nIt is used in the following flux objectives:\n" + fluxObj;
+				msg += "\n\nIt is used in the following flux objectives:\n" + fluxObj;
 			}
 			
-			SBMLutilities.message.setErrorDialog("Unable To Remove Variable", message);
+			Message message = new Message();
+      message.setDialog("Unable To Remove Variable", msg);
+      
+      if(observable != null)
+      {
+        observable.notifyObservers(message);
+      }
+      if(observer != null)
+      {
+        observer.update(message);
+      }
+      observable.notifyObservers(message);
+      message.setConsole(msg);
 			
 		}
 		return inUse;
@@ -5686,15 +5703,14 @@ public class SBMLutilities
 
 	}
 	
-	private static SBMLDocument convertToFBCVersion2(String filename,SBMLDocument document) throws XMLStreamException, IOException 
+	private static SBMLDocument convertToFBCVersion2(String filename,SBMLDocument document) throws XMLStreamException, IOException, BioSimException 
 	{
 		if (document.getDeclaredNamespaces().get("xmlns:"+FBCConstants.shortLabel)!=null &&
 				document.getDeclaredNamespaces().get("xmlns:"+FBCConstants.shortLabel).endsWith("1")) 
 		{
 			if (!Executables.libsbmlFound)
 			{
-			  SBMLutilities.message.setErrorDialog("Error Opening File", "Unable convert FBC model from Version 1 to Version 2.");
-				return null;
+			  throw new BioSimException("Unable convert FBC model from Version 1 to Version 2.", "Error Opening File");
 			}
 			//long numErrors = 0;
 			org.sbml.libsbml.SBMLReader reader = new org.sbml.libsbml.SBMLReader();
@@ -5723,7 +5739,7 @@ public class SBMLutilities
 		return document;
 	}
 
-	public static SBMLDocument readSBML(String filename) throws XMLStreamException, IOException
+	public static SBMLDocument readSBML(String filename, BioObservable observable, BioObserver observer) throws XMLStreamException, IOException, BioSimException
 	{
 		SBMLDocument document = null;
 		document = SBMLReader.read(new File(filename));
@@ -5757,18 +5773,31 @@ public class SBMLutilities
 			numErrors = doc.checkL3v2Compatibility();
 			if (numErrors > 0)
 			{
-				String message = "Conversion to SBML level " + GlobalConstants.SBML_LEVEL + " version " + GlobalConstants.SBML_VERSION
+				String msg = "Conversion to SBML level " + GlobalConstants.SBML_LEVEL + " version " + GlobalConstants.SBML_VERSION
 						+ " produced the errors listed below.";
-				message += "It is recommended that you fix them before using these models or you may get unexpected results.\n\n";
-				message += "--------------------------------------------------------------------------------------\n";
-				message += filename;
-				message += "\n--------------------------------------------------------------------------------------\n\n";
+				msg += "It is recommended that you fix them before using these models or you may get unexpected results.\n\n";
+				msg += "--------------------------------------------------------------------------------------\n";
+				msg += filename;
+				msg += "\n--------------------------------------------------------------------------------------\n\n";
 				for (int i = 0; i < numErrors; i++)
 				{
 					String error = doc.getError(i).getMessage();
-					message += i + ":" + error + "\n";
+					msg += i + ":" + error + "\n";
 				}
-				SBMLutilities.message.setConsole(message);
+				
+				Message message = new Message();
+				message.setDialog("SBML Conversion Errors and Warnings", msg);
+				
+				if(observable != null)
+				{
+				  observable.notifyObservers(message);
+				}
+				if(observer != null)
+				{
+				  observer.update(message);
+				}
+				observable.notifyObservers(message);
+				message.setConsole(msg);
 			}
 			convertToL3(doc);
 			doc.setLevelAndVersion(GlobalConstants.SBML_LEVEL, GlobalConstants.SBML_VERSION, false);
@@ -6067,7 +6096,7 @@ public class SBMLutilities
 		}
 	}
 
-	public static String changeIdToPortRef(String root, SBaseRef sbaseRef, BioModel bioModel) throws XMLStreamException, IOException
+	public static String changeIdToPortRef(String root, SBaseRef sbaseRef, BioModel bioModel) throws XMLStreamException, IOException, BioSimException
 	{
 		String id = "";
 		if (sbaseRef.isSetSBaseRef())
@@ -6145,7 +6174,7 @@ public class SBMLutilities
 		return "";
 	}
 
-	public static boolean updatePortMap(String root, CompSBasePlugin sbmlSBase, BioModel subModel, String subModelId) throws XMLStreamException, IOException
+	public static boolean updatePortMap(String root, CompSBasePlugin sbmlSBase, BioModel subModel, String subModelId) throws XMLStreamException, IOException, BioSimException
 	{
 		boolean updated = false;
 		if (sbmlSBase.isSetListOfReplacedElements())
@@ -6173,7 +6202,7 @@ public class SBMLutilities
 	}
 
 	public static boolean updateReplacementsDeletions(String root, SBMLDocument document, CompSBMLDocumentPlugin sbmlComp,
-			CompModelPlugin sbmlCompModel) throws XMLStreamException, IOException
+			CompModelPlugin sbmlCompModel) throws XMLStreamException, IOException, BioSimException
 	{
 		for (int i = 0; i < sbmlCompModel.getListOfSubmodels().size(); i++)
 		{

--- a/dataModels/src/main/java/edu/utah/ece/async/ibiosim/dataModels/biomodel/util/SBMLutilities.java
+++ b/dataModels/src/main/java/edu/utah/ece/async/ibiosim/dataModels/biomodel/util/SBMLutilities.java
@@ -6072,7 +6072,7 @@ public class SBMLutilities
 		String id = "";
 		if (sbaseRef.isSetSBaseRef())
 		{
-			BioModel subModel = new BioModel(root);
+			BioModel subModel = BioModel.createBioModel(root, bioModel);
 			Submodel submodel = bioModel.getSBMLCompModel().getListOfSubmodels().get(sbaseRef.getIdRef());
 			String extModel = bioModel.getSBMLComp().getListOfExternalModelDefinitions().get(submodel.getModelRef()).getSource()
 					.replace("file://", "").replace("file:", "").replace(".gcm", ".xml");

--- a/dataModels/src/main/java/edu/utah/ece/async/ibiosim/dataModels/biomodel/util/SBMLutilities.java
+++ b/dataModels/src/main/java/edu/utah/ece/async/ibiosim/dataModels/biomodel/util/SBMLutilities.java
@@ -2634,8 +2634,7 @@ public class SBMLutilities extends CoreObservable
 			}
 			
 			Message message = new Message();
-      message.setDialog("Unable To Remove Variable", msg);
-      
+      message.setErrorDialog("Unable To Remove Variable", msg);
       if(observable != null)
       {
         observable.notifyObservers(message);
@@ -2644,8 +2643,6 @@ public class SBMLutilities extends CoreObservable
       {
         observer.update(message);
       }
-      observable.notifyObservers(message);
-      message.setConsole(msg);
 			
 		}
 		return inUse;

--- a/dataModels/src/main/java/edu/utah/ece/async/ibiosim/dataModels/biomodel/util/Utility.java
+++ b/dataModels/src/main/java/edu/utah/ece/async/ibiosim/dataModels/biomodel/util/Utility.java
@@ -55,6 +55,7 @@ import org.sbml.libsbml.libsbmlConstants;
 
 import edu.utah.ece.async.ibiosim.dataModels.util.Executables;
 import edu.utah.ece.async.ibiosim.dataModels.util.GlobalConstants;
+import edu.utah.ece.async.ibiosim.dataModels.util.exceptions.BioSimException;
 
 import org.sbml.jsbml.ModifierSpeciesReference;
 
@@ -302,11 +303,6 @@ public class Utility {
 		return allFiles.list(Utility.getFilter(filter));			
 	}
 	
-	public static SBMLDocument openDocument(String filename) throws XMLStreamException, IOException {
-		SBMLDocument document = SBMLutilities.readSBML(filename);
-		return document;
-	}
-
 	public static HashMap<String, double[]> calculateAverage(String folder) {
 		HashMap<String, double[]> result = new HashMap<String, double[]>();
 		HashMap<String, double[]> average = null;

--- a/dataModels/src/main/java/edu/utah/ece/async/ibiosim/dataModels/util/Message.java
+++ b/dataModels/src/main/java/edu/utah/ece/async/ibiosim/dataModels/util/Message.java
@@ -25,6 +25,7 @@ public class Message {
   public static enum MessageType
   {
       ERROR,
+      SCROLLABLE_ERROR,
       DIALOG,
       LOG,
       CONSOLE,
@@ -43,6 +44,12 @@ public class Message {
     this.type = MessageType.NONE;
   }
   
+  public void setScrollableErrorDialog(String title, String message)
+  {
+    this.type = MessageType.SCROLLABLE_ERROR;
+    this.message = message;
+    this.title = title;
+  }
   
   public void setErrorDialog(String title, String message)
   {
@@ -105,6 +112,10 @@ public class Message {
     return this.type == MessageType.ERROR;
   }
   
+  public boolean isScrollableErrorDialog()
+  {
+    return this.type == MessageType.SCROLLABLE_ERROR;
+  }
   
   public String getMessage()
   {

--- a/dataModels/src/main/java/edu/utah/ece/async/ibiosim/dataModels/util/Validate.java
+++ b/dataModels/src/main/java/edu/utah/ece/async/ibiosim/dataModels/util/Validate.java
@@ -30,15 +30,11 @@ import org.sbml.libsbml.libsbmlConstants;
 
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.util.SBMLutilities;
 import edu.utah.ece.async.ibiosim.dataModels.util.exceptions.BioSimException;
+import edu.utah.ece.async.ibiosim.dataModels.util.observe.BioObservable;
+import edu.utah.ece.async.ibiosim.dataModels.util.observe.BioObserver;
 
 public class Validate 
 {
-  private static final Message errorMessage = new Message();
-  public static String getMessage()
-  {
-    return errorMessage.getMessage();
-  }
-
   
   /**
    * Check consistency of sbml file.
@@ -52,7 +48,7 @@ public class Validate
    * @throws XMLStreamException
    * @throws BioSimException
    */
-  public static boolean validateDoc(String file, SBMLDocument doc, boolean overdeterminedOnly) throws IOException, SBMLException, XMLStreamException, BioSimException
+  public static boolean validateDoc(String file, SBMLDocument doc, boolean overdeterminedOnly, BioObservable observable, BioObserver observer) throws IOException, SBMLException, XMLStreamException, BioSimException
   {
     // TODO: added to turn off checking until libsbml bug is found
     //if (true) {
@@ -216,10 +212,21 @@ public class Validate
         }
       }
     }
-
+    
+    
     if (numErrors > 0)
     {
+      Message errorMessage = new Message();
       errorMessage.setLog(message);
+      
+      if(observable != null)
+      {
+        observable.notifyObservers(errorMessage);
+      }
+      if(observer != null)
+      {
+        observer.update(errorMessage);
+      }
       return true;
     }
 

--- a/dataModels/src/main/java/edu/utah/ece/async/ibiosim/dataModels/util/Validate.java
+++ b/dataModels/src/main/java/edu/utah/ece/async/ibiosim/dataModels/util/Validate.java
@@ -13,20 +13,14 @@
  *******************************************************************************/
 package edu.utah.ece.async.ibiosim.dataModels.util;
 
-import static org.junit.Assert.assertTrue;
-
 import java.io.IOException;
 import java.util.List;
 import java.util.prefs.Preferences;
 
-import javax.swing.JOptionPane;
-import javax.swing.JScrollPane;
-import javax.swing.JTextArea;
 import javax.xml.stream.XMLStreamException;
 
 import org.sbml.jsbml.SBMLDocument;
 import org.sbml.jsbml.SBMLError;
-import org.sbml.jsbml.SBMLErrorLog;
 import org.sbml.jsbml.SBMLException;
 import org.sbml.jsbml.SBMLWriter;
 import org.sbml.jsbml.ext.arrays.validator.ArraysValidator;
@@ -35,6 +29,7 @@ import org.sbml.libsbml.libsbml;
 import org.sbml.libsbml.libsbmlConstants;
 
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.util.SBMLutilities;
+import edu.utah.ece.async.ibiosim.dataModels.util.exceptions.BioSimException;
 
 public class Validate 
 {
@@ -44,10 +39,20 @@ public class Validate
     return errorMessage.getMessage();
   }
 
+  
   /**
-   * Checks consistency of the sbml file.
+   * Check consistency of sbml file.
+   * 
+   * @param file
+   * @param doc
+   * @param overdeterminedOnly
+   * @return
+   * @throws IOException
+   * @throws SBMLException
+   * @throws XMLStreamException
+   * @throws BioSimException
    */
-  public static boolean validateDoc(String file, SBMLDocument doc, boolean overdeterminedOnly) throws IOException, SBMLException, XMLStreamException
+  public static boolean validateDoc(String file, SBMLDocument doc, boolean overdeterminedOnly) throws IOException, SBMLException, XMLStreamException, BioSimException
   {
     // TODO: added to turn off checking until libsbml bug is found
     //if (true) {
@@ -157,7 +162,7 @@ public class Validate
       SBMLDocument document = doc;
       if (document == null)
       {
-        document = SBMLutilities.readSBML(file);
+        document = SBMLutilities.readSBML(file, null, null);
       }
       if (overdeterminedOnly)
       {

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/Gui.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/Gui.java
@@ -2907,7 +2907,7 @@ public class Gui implements BioObserver, MouseListener, ActionListener, MouseMot
 					out.close();
 					String[] file = GlobalConstants.splitPath(filename.trim());
 					SBMLDocument document = SBMLutilities.readSBML(root + File.separator + filename.trim(), null, this);
-					Utils.check(root + File.separator + filename.trim(), document, false);
+					Utils.check(root + File.separator + filename.trim(), document, false, null, this);
 					SBMLWriter writer = new SBMLWriter();
 					writer.writeSBMLToFile(document, root + File.separator + file[file.length - 1]);
 					addToTree(file[file.length - 1]);
@@ -3662,7 +3662,7 @@ public class Gui implements BioObserver, MouseListener, ActionListener, MouseMot
 			throws SBMLException, FileNotFoundException, XMLStreamException {
 		String newFile = null;
 		SBMLutilities.checkModelCompleteness(document, true);
-		Utils.check(null, document, false);
+		Utils.check(null, document, false, null, this);
 		newFile = file;
 		newFile = newFile.replaceAll("[^a-zA-Z0-9_.]+", "_");
 		if (Character.isDigit(newFile.charAt(0))) {
@@ -9032,8 +9032,14 @@ public class Gui implements BioObserver, MouseListener, ActionListener, MouseMot
     if (message.isConsole()) {
       System.out.println(message.getMessage());
     } else if (message.isErrorDialog()) {
-      JOptionPane.showMessageDialog(Gui.frame, message.getMessage(), message.getTitle(),
-          JOptionPane.ERROR_MESSAGE);
+      JTextArea messageArea = new JTextArea(message.getMessage());
+      messageArea.setLineWrap(true);
+      messageArea.setEditable(false);
+      JScrollPane scroll = new JScrollPane();
+      scroll.setMinimumSize(new java.awt.Dimension(600, 600));
+      scroll.setPreferredSize(new java.awt.Dimension(600, 600));
+      scroll.setViewportView(messageArea);
+      JOptionPane.showMessageDialog(Gui.frame, scroll, message.getTitle(), JOptionPane.ERROR_MESSAGE);
     } else if (message.isDialog()) {
       JOptionPane.showMessageDialog(Gui.frame, message.getMessage(), message.getTitle(),
           JOptionPane.PLAIN_MESSAGE);

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/Gui.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/Gui.java
@@ -3798,6 +3798,7 @@ public class Gui implements BioObserver, MouseListener, ActionListener, MouseMot
 		Xwriter.write(sbmlDoc, root + File.separator + "_" + modelFileName);
 		AnalysisProperties properties;
 		properties = new AnalysisProperties(analysisId, modelFileName, root, false);
+		properties.addObserver(this);
 	    BioModel biomodel = new BioModel(root + File.separator);
 	    biomodel.addObserver(this);
 	    biomodel.load(root + File.separator + "_" + modelFileName);

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/Gui.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/Gui.java
@@ -3644,6 +3644,7 @@ public class Gui implements BioObserver, MouseListener, ActionListener, MouseMot
 							}
 							ModelEditor modelEditor = new ModelEditor(root + File.separator, modelId, this,
 									log, false, null, null, null, false, grid, lema);
+							modelEditor.addObserver(this);
 							modelEditor.save(false);
 							addTab(modelId, modelEditor, "Model Editor");
 							addToTree(modelId);
@@ -5804,6 +5805,7 @@ public class Gui implements BioObserver, MouseListener, ActionListener, MouseMot
 			String path = work.getAbsolutePath();
 			try {
 				ModelEditor gcm = new ModelEditor(path, filename, this, log, false, null, null, null, textBased, false, lema);
+				gcm.addObserver(this);
 				addTab(filename, gcm, "Model Editor");
 			} catch (Exception e) {
 				e.printStackTrace();
@@ -5829,6 +5831,7 @@ public class Gui implements BioObserver, MouseListener, ActionListener, MouseMot
 				// addToTree(theGCMFile);
 				ModelEditor gcm = new ModelEditor(root + File.separator, theGCMFile, this, log, false, null,
 						null, null, false, false, lema);
+				gcm.addObserver(this);
 				addTab(theSBMLFile, gcm, "Model Editor");
 			}
 		} catch (Exception e1) {
@@ -7320,6 +7323,7 @@ public class Gui implements BioObserver, MouseListener, ActionListener, MouseMot
 				try {
 					modelEditor = new ModelEditor(root + File.separator, solutionFileIDs.get(0), this, log,
 							false, null, null, null, false, false, false);
+					modelEditor.addObserver(this);
 					ActionEvent applyLayout = new ActionEvent(synthView, ActionEvent.ACTION_PERFORMED,
 							"layout_verticalHierarchical");
 					modelEditor.getSchematic().actionPerformed(applyLayout);

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/Gui.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/Gui.java
@@ -9029,9 +9029,17 @@ public class Gui implements BioObserver, MouseListener, ActionListener, MouseMot
 
   @Override
   public void update(Message message) {
-    if (message.isConsole()) {
+    if (message.isConsole()) 
+    {
       System.out.println(message.getMessage());
-    } else if (message.isErrorDialog()) {
+    } 
+    else if(message.isErrorDialog())
+    {
+      JOptionPane.showMessageDialog(frame, message.getMessage(), message.getTitle(), JOptionPane.ERROR_MESSAGE);
+      
+    }
+    else if (message.isScrollableErrorDialog()) 
+    {
       JTextArea messageArea = new JTextArea(message.getMessage());
       messageArea.setLineWrap(true);
       messageArea.setEditable(false);
@@ -9040,10 +9048,14 @@ public class Gui implements BioObserver, MouseListener, ActionListener, MouseMot
       scroll.setPreferredSize(new java.awt.Dimension(600, 600));
       scroll.setViewportView(messageArea);
       JOptionPane.showMessageDialog(Gui.frame, scroll, message.getTitle(), JOptionPane.ERROR_MESSAGE);
-    } else if (message.isDialog()) {
+    } 
+    else if (message.isDialog()) 
+    {
       JOptionPane.showMessageDialog(Gui.frame, message.getMessage(), message.getTitle(),
           JOptionPane.PLAIN_MESSAGE);
-    } else if (message.isLog()) {
+    } 
+    else if (message.isLog()) 
+    {
       log.addText(message.getMessage());
     }
     

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/Gui.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/Gui.java
@@ -2906,7 +2906,7 @@ public class Gui implements BioObserver, MouseListener, ActionListener, MouseMot
 					out.write(model);
 					out.close();
 					String[] file = GlobalConstants.splitPath(filename.trim());
-					SBMLDocument document = SBMLutilities.readSBML(root + File.separator + filename.trim());
+					SBMLDocument document = SBMLutilities.readSBML(root + File.separator + filename.trim(), null, this);
 					Utils.check(root + File.separator + filename.trim(), document, false);
 					SBMLWriter writer = new SBMLWriter();
 					writer.writeSBMLToFile(document, root + File.separator + file[file.length - 1]);
@@ -3692,7 +3692,11 @@ public class Gui implements BioObserver, MouseListener, ActionListener, MouseMot
 				JOptionPane.showMessageDialog(Gui.frame, "I/O error when opening SBML file", "Error Opening File",
 						JOptionPane.ERROR_MESSAGE);
 				e.printStackTrace();
-			}
+			} catch (BioSimException e) {
+			  JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+          JOptionPane.ERROR_MESSAGE);
+        e.printStackTrace();
+      }
 			SBMLWriter writer = new SBMLWriter();
 			if (document.getModel().getId() == null || document.getModel().getId().equals("")) {
 				document.getModel().setId(newFile.replace(".xml", ""));
@@ -3719,7 +3723,7 @@ public class Gui implements BioObserver, MouseListener, ActionListener, MouseMot
 	private String importSBMLFile(String filename,boolean open) {
 		String newFile = null;
 		try {
-			SBMLDocument document = SBMLutilities.readSBML(filename.trim());
+			SBMLDocument document = SBMLutilities.readSBML(filename.trim(), null, this);
 			if (document == null)
 				return null;
 			String[] file = GlobalConstants.splitPath(filename.trim());
@@ -4181,7 +4185,7 @@ public class Gui implements BioObserver, MouseListener, ActionListener, MouseMot
 			if (entry.getFormat().toString().contains("sbml")) {
 				try {
 					String fileName = entry.extractFile (new File(path + File.separator + entry.getFileName())).getAbsolutePath();
-					SBMLDocument document = SBMLutilities.readSBML(entry.extractFile (new File(path + File.separator + entry.getFileName())).getAbsolutePath());
+					SBMLDocument document = SBMLutilities.readSBML(entry.extractFile (new File(path + File.separator + entry.getFileName())).getAbsolutePath(), null, this);
 					SBMLWriter writer = new SBMLWriter();
 					String[] file = GlobalConstants.splitPath(fileName.trim());
 					writer.writeSBMLToFile(document, root + File.separator + file[file.length - 1]);
@@ -4189,7 +4193,10 @@ public class Gui implements BioObserver, MouseListener, ActionListener, MouseMot
 				catch (XMLStreamException e) {
 					// TODO Auto-generated catch block
 					e.printStackTrace();
-				}
+				} catch (BioSimException e) {
+				  JOptionPane.showMessageDialog(frame, e.getMessage(), e.getTitle(),
+            JOptionPane.ERROR_MESSAGE);
+        }
 			}
 		}
 		for (ArchiveEntry entry : ca.getEntries ())
@@ -5320,12 +5327,12 @@ public class Gui implements BioObserver, MouseListener, ActionListener, MouseMot
 	}
 
 	private void copyDirectory(String srcDir, String destDir, String copyName)
-			throws SBMLException, XMLStreamException, IOException {
+			throws SBMLException, XMLStreamException, IOException, BioSimException {
 		new File(destDir).mkdir();
 		String[] files = new File(srcDir).list();
 		for (String file : files) {
 			if (file.endsWith(".sbml") || file.equals(".xml")) {
-				SBMLDocument document = SBMLutilities.readSBML(srcDir + File.separator + file);
+				SBMLDocument document = SBMLutilities.readSBML(srcDir + File.separator + file, null, this);
 				SBMLWriter writer = new SBMLWriter();
 				writer.writeSBMLToFile(document, destDir + File.separator + file);
 			} else if (new File(srcDir + File.separator + file).isFile()) {
@@ -5383,7 +5390,7 @@ public class Gui implements BioObserver, MouseListener, ActionListener, MouseMot
 				if (checkFiles(oldName, copy)) {
 					if (overwrite(root + File.separator + copy, copy)) {
 						if (copy.endsWith(".xml")) {
-							SBMLDocument document = SBMLutilities.readSBML(tree.getFile());
+							SBMLDocument document = SBMLutilities.readSBML(tree.getFile(), null, this);
 							List<URI> sbolURIs = new LinkedList<URI>();
 							String sbolStrand = AnnotationUtility.parseSBOLAnnotation(document.getModel(), sbolURIs);
 							Iterator<URI> sbolIterator = sbolURIs.iterator();
@@ -5714,7 +5721,7 @@ public class Gui implements BioObserver, MouseListener, ActionListener, MouseMot
 						}
 						if (tree.getFile().endsWith(".xml")) {
 							new File(tree.getFile()).renameTo(new File(root + File.separator + newName));
-							SBMLDocument document = SBMLutilities.readSBML(root + File.separator + newName);
+							SBMLDocument document = SBMLutilities.readSBML(root + File.separator + newName, null, this);
 							document.getModel().setId(modelID);
 							SBMLWriter writer = new SBMLWriter();
 							writer.writeSBMLToFile(document, root + File.separator + newName);
@@ -5772,7 +5779,10 @@ public class Gui implements BioObserver, MouseListener, ActionListener, MouseMot
 				e.printStackTrace();
 			} catch (XMLStreamException e) {
 				e.printStackTrace();
-			}
+			} catch (BioSimException e) {
+			  JOptionPane.showMessageDialog(frame, e.getMessage(), e.getTitle(),
+          JOptionPane.ERROR_MESSAGE);
+      }
 		}
 	}
 
@@ -6099,6 +6109,11 @@ public class Gui implements BioObserver, MouseListener, ActionListener, MouseMot
 								JOptionPane.ERROR_MESSAGE);
 						e.printStackTrace();
 					}
+					catch (BioSimException e) {
+		        JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+		          JOptionPane.ERROR_MESSAGE);
+		        e.printStackTrace();
+		      }
 				}
 			}
 		} catch (IOException e) {
@@ -6900,6 +6915,11 @@ public class Gui implements BioObserver, MouseListener, ActionListener, MouseMot
 		} catch (IOException e1) {
 			JOptionPane.showMessageDialog(frame, "Unable to save genetic circuit.", "Error", JOptionPane.ERROR_MESSAGE);
 		}
+		catch (BioSimException e) {
+      JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+        JOptionPane.ERROR_MESSAGE);
+      e.printStackTrace();
+    }
 	}
 
 	public void copySFiles(String filename, String directory) {
@@ -8950,6 +8970,11 @@ public class Gui implements BioObserver, MouseListener, ActionListener, MouseMot
 							JOptionPane.ERROR_MESSAGE);
 					e.printStackTrace();
 				}
+				catch (BioSimException e) {
+	        JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+	          JOptionPane.ERROR_MESSAGE);
+	        e.printStackTrace();
+	      }
 				SBMLutilities.checkModelCompleteness(document, true);
 				SBMLWriter writer = new SBMLWriter();
 				try {

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/Gui.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/Gui.java
@@ -3635,7 +3635,7 @@ public class Gui implements BioObserver, MouseListener, ActionListener, MouseMot
 								"Invalid ID", JOptionPane.ERROR_MESSAGE);
 					} else {
 						if (overwrite(root + File.separator + modelId, modelId)) {
-							BioModel bioModel = new BioModel(root);
+							BioModel bioModel = BioModel.createBioModel(root, this);
 							bioModel.createSBMLDocument(modelId.replace(".xml", ""), grid, false);
 							bioModel.save(root + File.separator + modelId);
 							int i = getTab(modelId);
@@ -3799,8 +3799,7 @@ public class Gui implements BioObserver, MouseListener, ActionListener, MouseMot
 		AnalysisProperties properties;
 		properties = new AnalysisProperties(analysisId, modelFileName, root, false);
 		properties.addObserver(this);
-	    BioModel biomodel = new BioModel(root + File.separator);
-	    biomodel.addObserver(this);
+	    BioModel biomodel =  BioModel.createBioModel(root + File.separator, this);
 	    biomodel.load(root + File.separator + "_" + modelFileName);
 	    SBMLDocument flatten = biomodel.flattenModel(true);
 	    String newFilename = root + File.separator + analysisId + File.separator + modelFileName;
@@ -6882,7 +6881,7 @@ public class Gui implements BioObserver, MouseListener, ActionListener, MouseMot
 				in.close();
 				out.close();
 
-				BioModel bioModel = new BioModel(root);
+				BioModel bioModel =  BioModel.createBioModel(root, this);
 				try {
 					bioModel.load(root + File.separator + filename);
 					GCM2SBML gcm2sbml = new GCM2SBML(bioModel);
@@ -8825,7 +8824,7 @@ public class Gui implements BioObserver, MouseListener, ActionListener, MouseMot
 					views.add(s);
 				}
 			} else if (s.endsWith(".xml") && filename.endsWith(".xml")) {
-				BioModel gcm = new BioModel(root);
+				BioModel gcm = BioModel.createBioModel(root, this);
 				try {
 					gcm.load(root + File.separator + s);
 					if (gcm.getSBMLComp() != null) {

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/analysisView/AnalysisView.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/analysisView/AnalysisView.java
@@ -201,6 +201,7 @@ public class AnalysisView extends PanelObservable implements ActionListener, Run
   private boolean change;
   
   private String root;
+  
   /**
    * This is the constructor for the GUI. It initializes all the input fields,
    * puts them on panels, adds the panels to the frame, and then displays the
@@ -227,7 +228,8 @@ public class AnalysisView extends PanelObservable implements ActionListener, Run
     super(new BorderLayout());
 
     this.properties = new AnalysisProperties(simName, modelFile, root, abstractionPanel == null);
-
+    properties.addObservable(this);
+    
     this.gui = gui;
     this.log = log;
     this.simTab = simTab;

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/analysisView/AnalysisView.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/analysisView/AnalysisView.java
@@ -3723,6 +3723,7 @@ public class AnalysisView extends PanelObservable implements ActionListener, Run
           try
           {
             ModelEditor gcm = new ModelEditor(properties.getRoot() + File.separator, sbmlName, gui, log, false, null, null, null, false, false, false);
+            gcm.addObservable(this);
             gui.addTab(sbmlName, gcm, "Model Editor");
             gui.addToTree(sbmlName);
           }

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/graphEditor/Graph.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/graphEditor/Graph.java
@@ -6453,7 +6453,7 @@ public class Graph extends PanelObservable implements ActionListener, MouseListe
 		      // END ADDED BY SB.
 		    }
 		    else {
-		      SBMLDocument document = SBMLutilities.readSBML(background);
+		      SBMLDocument document = SBMLutilities.readSBML(background, this, null);
 		      Model model = document.getModel();
 		      ListOf<Species> ids = model.getListOfSpecies();
 		      for (int i = 0; i < model.getSpeciesCount(); i++) {

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/graphEditor/Graph.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/graphEditor/Graph.java
@@ -6416,7 +6416,7 @@ public class Graph extends PanelObservable implements ActionListener, MouseListe
 		  learnSpecs = new ArrayList<String>();
 		  if (background != null) {
 		    if (background.endsWith(".gcm")) {
-		      BioModel gcm = new BioModel(gui.getRoot());
+		      BioModel gcm =  BioModel.createBioModel(gui.getRoot(), this);
 		      gcm.load(background);
 		      learnSpecs = gcm.getSpecies();
 		    }

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/learnView/DataManager.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/learnView/DataManager.java
@@ -1153,7 +1153,7 @@ public class DataManager extends PanelObservable implements ActionListener, Tabl
 		if (background != null) {
 			if (background.contains(".gcm")) {
 				ArrayList<String> getSpecies = new ArrayList<String>();
-				BioModel gcm = new BioModel(biosim.getRoot());
+				BioModel gcm =  BioModel.createBioModel(biosim.getRoot(), this);
 				try {
           gcm.load(background);
 

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/learnView/DataManager.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/learnView/DataManager.java
@@ -1166,6 +1166,11 @@ public class DataManager extends PanelObservable implements ActionListener, Tabl
           JOptionPane.showMessageDialog(Gui.frame, "I/O error when opening SBML file", "Error Opening File", JOptionPane.ERROR_MESSAGE);
           e.printStackTrace();
         }
+				catch (BioSimException e) {
+	        JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+	          JOptionPane.ERROR_MESSAGE);
+	        e.printStackTrace();
+	      }
 			}
 			else if (background.contains(".lpn")) {
 				ArrayList<String> getSpecies = new ArrayList<String>();
@@ -1215,7 +1220,7 @@ public class DataManager extends PanelObservable implements ActionListener, Tabl
 			else {
 				SBMLDocument document;
         try {
-          document = SBMLutilities.readSBML(background);
+          document = SBMLutilities.readSBML(background, this, null);
           Model model = document.getModel();
           ArrayList<String> getSpecies = new ArrayList<String>();
           for (int i = 0; i < model.getSpeciesCount(); i++) {
@@ -1231,6 +1236,10 @@ public class DataManager extends PanelObservable implements ActionListener, Tabl
           e.printStackTrace();
         } catch (IOException e) {
           JOptionPane.showMessageDialog(Gui.frame, "I/O error when opening SBML file", "Error Opening File", JOptionPane.ERROR_MESSAGE);
+          e.printStackTrace();
+        } catch (BioSimException e) {
+          JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+            JOptionPane.ERROR_MESSAGE);
           e.printStackTrace();
         }
 			}

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/learnView/LearnView.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/learnView/LearnView.java
@@ -498,7 +498,7 @@ public class LearnView extends JPanel implements ActionListener, Runnable
     {
       speciesList = Learn.writeBackgroundFile(learnFile, directory);
     } 
-    catch (XMLStreamException | IOException e) 
+    catch (XMLStreamException | IOException | BioSimException e) 
     {
       JOptionPane.showMessageDialog(Gui.frame, "Unable to create background file!", "Error Writing Background", JOptionPane.ERROR_MESSAGE);
       speciesList = new ArrayList<String>();
@@ -1812,7 +1812,7 @@ public class LearnView extends JPanel implements ActionListener, Runnable
     {
       speciesList = Learn.writeBackgroundFile(learnFile, directory);
     } 
-    catch (XMLStreamException | IOException e) 
+    catch (XMLStreamException | IOException | BioSimException e) 
     {
       JOptionPane.showMessageDialog(Gui.frame, "Unable to create background file!", "Error Writing Background", JOptionPane.ERROR_MESSAGE);
       speciesList = new ArrayList<String>();

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/comp/DropComponentPanel.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/comp/DropComponentPanel.java
@@ -34,6 +34,7 @@ import javax.xml.stream.XMLStreamException;
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.parser.BioModel;
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.util.Utility;
 import edu.utah.ece.async.ibiosim.dataModels.util.GlobalConstants;
+import edu.utah.ece.async.ibiosim.dataModels.util.observe.PanelObservable;
 import edu.utah.ece.async.ibiosim.gui.Gui;
 import edu.utah.ece.async.ibiosim.gui.modelEditor.schematic.ModelEditor;
 
@@ -43,7 +44,7 @@ import edu.utah.ece.async.ibiosim.gui.modelEditor.schematic.ModelEditor;
  * @author <a href="http://www.async.ece.utah.edu/ibiosim#Credits"> iBioSim Contributors </a>
  * @version %I%
  */
-public class DropComponentPanel extends JPanel implements ActionListener {
+public class DropComponentPanel extends PanelObservable implements ActionListener {
 	
 	/**
 	 * 
@@ -214,7 +215,7 @@ public class DropComponentPanel extends JPanel implements ActionListener {
 				//name of the component
 				String component = (String)componentChooser.getSelectedItem();
 				
-				BioModel compGCM = new BioModel(bioModel.getPath());
+				BioModel compGCM =  BioModel.createBioModel(bioModel.getPath(), this);
 				
 				//don't allow dropping a grid component
 				try {
@@ -292,7 +293,7 @@ public class DropComponentPanel extends JPanel implements ActionListener {
 		double width = grid.getComponentGeomWidth();
 		double height = grid.getComponentGeomHeight();
 		
-		BioModel compGCMFile = new BioModel(bioModel.getPath());
+		BioModel compGCMFile = BioModel.createBioModel(bioModel.getPath(), this);
 		try {
       compGCMFile.load(bioModel.getPath() + File.separator + component);
 	  } catch (XMLStreamException e) {
@@ -348,7 +349,7 @@ public class DropComponentPanel extends JPanel implements ActionListener {
 				//name of the component
 				String component = (String)componentCombo.getSelectedItem();
 				
-				BioModel compGCM = new BioModel(bioModel.getPath());
+				BioModel compGCM =  BioModel.createBioModel(bioModel.getPath(), this);
 				
 				//don't allow grids within a grid
 				try {
@@ -445,7 +446,7 @@ public class DropComponentPanel extends JPanel implements ActionListener {
 		//sets location(s) for all of the tiled component(s)
 		for(int row=0; row<rowCount; row++) {
 			for(int col=0; col<colCount; col++) {
-				BioModel compBioModel = new BioModel(bioModel.getPath());
+				BioModel compBioModel = BioModel.createBioModel(bioModel.getPath(), this);
 				try {
           compBioModel.load(bioModel.getPath() + File.separator + comp);
         } catch (XMLStreamException e) {

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/comp/DropComponentPanel.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/comp/DropComponentPanel.java
@@ -34,6 +34,7 @@ import javax.xml.stream.XMLStreamException;
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.parser.BioModel;
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.util.Utility;
 import edu.utah.ece.async.ibiosim.dataModels.util.GlobalConstants;
+import edu.utah.ece.async.ibiosim.dataModels.util.exceptions.BioSimException;
 import edu.utah.ece.async.ibiosim.dataModels.util.observe.PanelObservable;
 import edu.utah.ece.async.ibiosim.gui.Gui;
 import edu.utah.ece.async.ibiosim.gui.modelEditor.schematic.ModelEditor;
@@ -269,6 +270,11 @@ public class DropComponentPanel extends PanelObservable implements ActionListene
           JOptionPane.showMessageDialog(Gui.frame, "I/O error when opening SBML file", "Error Opening File", JOptionPane.ERROR_MESSAGE);
           e.printStackTrace();
         }
+				catch (BioSimException e) {
+	        JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+	          JOptionPane.ERROR_MESSAGE);
+	        e.printStackTrace();
+	      }
 			}
 			else {
 				
@@ -303,6 +309,12 @@ public class DropComponentPanel extends PanelObservable implements ActionListene
       JOptionPane.showMessageDialog(Gui.frame, "I/O error when opening SBML file", "Error Opening File", JOptionPane.ERROR_MESSAGE);
       e.printStackTrace();
     }
+		catch (BioSimException e) {
+      JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+        JOptionPane.ERROR_MESSAGE);
+      e.printStackTrace();
+    }
+		
 		String md5 = Utility.MD5(compGCMFile.getSBMLDocument());
 		return bioModel.addComponent(null, component, compGCMFile.IsWithinCompartment(), compGCMFile.getCompartmentPorts(), row, col, 
 				col * (width + padding) + padding, row * (height + padding) + padding,md5);
@@ -379,6 +391,11 @@ public class DropComponentPanel extends PanelObservable implements ActionListene
           JOptionPane.showMessageDialog(Gui.frame, "I/O error when opening SBML file", "Error Opening File", JOptionPane.ERROR_MESSAGE);
           e.printStackTrace();
         }
+				catch (BioSimException e) {
+	        JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+	          JOptionPane.ERROR_MESSAGE);
+	        e.printStackTrace();
+	      }
 			}
 			else {
 				this.droppedComponent = false;
@@ -456,6 +473,12 @@ public class DropComponentPanel extends PanelObservable implements ActionListene
           JOptionPane.showMessageDialog(Gui.frame, "I/O error when opening SBML file", "Error Opening File", JOptionPane.ERROR_MESSAGE);
           e.printStackTrace();
         }
+				catch (BioSimException e) {
+	        JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+	          JOptionPane.ERROR_MESSAGE);
+	        e.printStackTrace();
+	      }
+				
 				String md5 = Utility.MD5(compBioModel.getSBMLDocument());
 				bioModel.addComponent(null, comp, compBioModel.IsWithinCompartment(), compBioModel.getCompartmentPorts(), -1, -1, 
 						col * separationX + topleftX, row * separationY + topleftY,md5);

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/comp/Grid.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/comp/Grid.java
@@ -35,6 +35,7 @@ import edu.utah.ece.async.ibiosim.dataModels.biomodel.parser.BioModel;
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.parser.GridTable;
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.util.Utility;
 import edu.utah.ece.async.ibiosim.dataModels.util.GlobalConstants;
+import edu.utah.ece.async.ibiosim.dataModels.util.observe.CoreObservable;
 import edu.utah.ece.async.ibiosim.gui.Gui;
 import edu.utah.ece.async.ibiosim.gui.modelEditor.schematic.BioGraph;
 
@@ -49,7 +50,7 @@ import edu.utah.ece.async.ibiosim.gui.modelEditor.schematic.BioGraph;
  * @author <a href="http://www.async.ece.utah.edu/ibiosim#Credits"> iBioSim Contributors </a>
  * @version %I%
  */
-public class Grid {
+public class Grid extends CoreObservable{
 	
 	
 	//---------------
@@ -1024,7 +1025,7 @@ public class Grid {
 		
 		//don't put blank components onto the grid or model
 		if (!compGCM.equals("none")) {
-			BioModel compGCMFile = new BioModel(bioModel.getPath());
+			BioModel compGCMFile = BioModel.createBioModel(bioModel.getPath(), this);
 			try {
         compGCMFile.load(bioModel.getPath() + File.separator + compGCM);
 		  } catch (XMLStreamException e) {

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/comp/Grid.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/comp/Grid.java
@@ -35,6 +35,7 @@ import edu.utah.ece.async.ibiosim.dataModels.biomodel.parser.BioModel;
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.parser.GridTable;
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.util.Utility;
 import edu.utah.ece.async.ibiosim.dataModels.util.GlobalConstants;
+import edu.utah.ece.async.ibiosim.dataModels.util.exceptions.BioSimException;
 import edu.utah.ece.async.ibiosim.dataModels.util.observe.CoreObservable;
 import edu.utah.ece.async.ibiosim.gui.Gui;
 import edu.utah.ece.async.ibiosim.gui.modelEditor.schematic.BioGraph;
@@ -1033,6 +1034,11 @@ public class Grid extends CoreObservable{
         e.printStackTrace();
       } catch (IOException e) {
         JOptionPane.showMessageDialog(Gui.frame, "I/O error when opening SBML file", "Error Opening File", JOptionPane.ERROR_MESSAGE);
+        e.printStackTrace();
+      }
+			catch (BioSimException e) {
+        JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+          JOptionPane.ERROR_MESSAGE);
         e.printStackTrace();
       }
 			String md5 = Utility.MD5(compGCMFile.getSBMLDocument());

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/comp/GridPanel.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/comp/GridPanel.java
@@ -31,6 +31,7 @@ import javax.xml.stream.XMLStreamException;
 
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.parser.BioModel;
 import edu.utah.ece.async.ibiosim.dataModels.util.GlobalConstants;
+import edu.utah.ece.async.ibiosim.dataModels.util.observe.PanelObservable;
 import edu.utah.ece.async.ibiosim.gui.Gui;
 import edu.utah.ece.async.ibiosim.gui.modelEditor.schematic.ModelEditor;
 
@@ -41,7 +42,7 @@ import edu.utah.ece.async.ibiosim.gui.modelEditor.schematic.ModelEditor;
  * @author <a href="http://www.async.ece.utah.edu/ibiosim#Credits"> iBioSim Contributors </a>
  * @version %I%
  */
-public class GridPanel extends JPanel implements ActionListener {
+public class GridPanel extends PanelObservable implements ActionListener {
 	
 	private static final long serialVersionUID = 1L;
 	private BioModel gcm;
@@ -145,8 +146,7 @@ public class GridPanel extends JPanel implements ActionListener {
 				//name of the component
 				String component = (String)componentChooser.getSelectedItem();
 				
-				BioModel compGCM = new BioModel(gcm.getPath());
-				
+				BioModel compGCM = BioModel.createBioModel(gcm.getPath(), this);
 				//don't allow dropping a grid component
 				try {
           if (component != "none" && compGCM.getGridEnabledFromFile(gcm.getPath() + 
@@ -273,8 +273,7 @@ public class GridPanel extends JPanel implements ActionListener {
 				
 				//name of the component
 				String component = (String)componentChooser.getSelectedItem();
-				BioModel compGCM = new BioModel(gcm.getPath());
-				
+				BioModel compGCM = BioModel.createBioModel(gcm.getPath(), this);
 				//don't allow dropping a grid component
 				try {
           if (!component.equals("none") && compGCM.getGridEnabledFromFile(gcm.getPath() + 

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/comp/GridPanel.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/comp/GridPanel.java
@@ -31,6 +31,7 @@ import javax.xml.stream.XMLStreamException;
 
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.parser.BioModel;
 import edu.utah.ece.async.ibiosim.dataModels.util.GlobalConstants;
+import edu.utah.ece.async.ibiosim.dataModels.util.exceptions.BioSimException;
 import edu.utah.ece.async.ibiosim.dataModels.util.observe.PanelObservable;
 import edu.utah.ece.async.ibiosim.gui.Gui;
 import edu.utah.ece.async.ibiosim.gui.modelEditor.schematic.ModelEditor;
@@ -169,6 +170,12 @@ public class GridPanel extends PanelObservable implements ActionListener {
           JOptionPane.showMessageDialog(Gui.frame, "I/O error when opening SBML file", "Error Opening File", JOptionPane.ERROR_MESSAGE);
           e.printStackTrace();
         }
+				catch (BioSimException e) {
+	        JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+	          JOptionPane.ERROR_MESSAGE);
+	        e.printStackTrace();
+	      }
+				
 				int rowCount = 0, colCount = 0;
 				
 				//try to get the number of rows and columns from the user
@@ -295,6 +302,11 @@ public class GridPanel extends PanelObservable implements ActionListener {
           JOptionPane.showMessageDialog(Gui.frame, "I/O error when opening SBML file", "Error Opening File", JOptionPane.ERROR_MESSAGE);
           e.printStackTrace();
         }
+				catch (BioSimException e) {
+	        JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+	          JOptionPane.ERROR_MESSAGE);
+	        e.printStackTrace();
+	      }
 				int rowCount = 0, colCount = 0;
 				
 				//try to get the number of rows and columns from the user

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/movie/MovieContainer.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/movie/MovieContainer.java
@@ -23,6 +23,7 @@ import edu.utah.ece.async.ibiosim.dataModels.util.GlobalConstants;
 import edu.utah.ece.async.ibiosim.dataModels.util.dataparser.DTSDParser;
 import edu.utah.ece.async.ibiosim.dataModels.util.dataparser.DataParser;
 import edu.utah.ece.async.ibiosim.dataModels.util.dataparser.TSDParser;
+import edu.utah.ece.async.ibiosim.dataModels.util.observe.PanelObservable;
 import edu.utah.ece.async.ibiosim.gui.Gui;
 import edu.utah.ece.async.ibiosim.gui.ResourceManager;
 import edu.utah.ece.async.ibiosim.gui.analysisView.AnalysisView;
@@ -75,7 +76,7 @@ import javax.swing.Timer;
  * @author <a href="http://www.async.ece.utah.edu/ibiosim#Credits"> iBioSim Contributors </a>
  * @version %I%
  */
-public class MovieContainer extends JPanel implements ActionListener {
+public class MovieContainer extends PanelObservable implements ActionListener {
 
 	public static final String COLOR_PREPEND = "_COLOR";
 	public static final String MIN_PREPEND = "_MIN";
@@ -141,6 +142,7 @@ public class MovieContainer extends JPanel implements ActionListener {
 		//JComboBox compartmentList = MySpecies.createCompartmentChoices(gcm);
 		schematic = new Schematic(bioModel, biosim, gcm2sbml, false, this, gcm2sbml.getCompartmentPanel(), gcm2sbml.getReactionPanel(), gcm2sbml.getRulePanel(),
 		  gcm2sbml.getConstraintPanel(),  gcm2sbml.getEventPanel(), gcm2sbml.getParameterPanel(), lema);
+		schematic.addObservable(this);
 		this.add(schematic, BorderLayout.CENTER);
 		
 		this.bioModel = bioModel;

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/sbmlcore/Compartments.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/sbmlcore/Compartments.java
@@ -47,6 +47,7 @@ import edu.utah.ece.async.ibiosim.dataModels.biomodel.parser.BioModel;
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.util.SBMLutilities;
 import edu.utah.ece.async.ibiosim.dataModels.util.GlobalConstants;
 import edu.utah.ece.async.ibiosim.dataModels.util.exceptions.BioSimException;
+import edu.utah.ece.async.ibiosim.dataModels.util.observe.PanelObservable;
 import edu.utah.ece.async.ibiosim.gui.Gui;
 import edu.utah.ece.async.ibiosim.gui.modelEditor.schematic.ModelEditor;
 import edu.utah.ece.async.ibiosim.gui.modelEditor.schematic.Utils;
@@ -66,7 +67,7 @@ import org.sbml.jsbml.UnitDefinition;
  * @author <a href="http://www.async.ece.utah.edu/ibiosim#Credits"> iBioSim Contributors </a>
  * @version %I%
  */
-public class Compartments extends JPanel implements ActionListener, MouseListener {
+public class Compartments extends PanelObservable implements ActionListener, MouseListener {
 
 	private static final long serialVersionUID = 1L;
 
@@ -348,6 +349,7 @@ public class Compartments extends JPanel implements ActionListener, MouseListene
 		compPanel.add(dimLabel);
 		compPanel.add(dimText);
 		if (paramsOnly) {
+		  Compartments instance = this;
 			JLabel typeLabel = new JLabel("Value Type:");
 			type.addActionListener(new ActionListener() {
 				@Override
@@ -361,7 +363,7 @@ public class Compartments extends JPanel implements ActionListener, MouseListene
 						compSize.setEnabled(false);
 						SBMLDocument d;
             try {
-              d = SBMLutilities.readSBML(file);
+              d = SBMLutilities.readSBML(file, instance, null);
 
               if (d.getModel().getCompartment(((String) compartments.getSelectedValue()).split(" ")[0]).isSetSize()) {
                 compSize.setText(d.getModel().getCompartment(((String) compartments.getSelectedValue()).split(" ")[0]).getSize() + "");
@@ -371,6 +373,11 @@ public class Compartments extends JPanel implements ActionListener, MouseListene
               e1.printStackTrace();
             } catch (IOException e1) {
               JOptionPane.showMessageDialog(Gui.frame, "I/O error when opening SBML file", "Error Opening File", JOptionPane.ERROR_MESSAGE);
+              e1.printStackTrace();
+            }
+            catch (BioSimException e1) {
+              JOptionPane.showMessageDialog(Gui.frame, e1.getMessage(), e1.getTitle(),
+                JOptionPane.ERROR_MESSAGE);
               e1.printStackTrace();
             }
 					}
@@ -796,7 +803,7 @@ public class Compartments extends JPanel implements ActionListener, MouseListene
 		if (index != -1) {
 			if (!Utils.compartmentInUse(bioModel.getSBMLDocument(),
 					((String) compartments.getSelectedValue()).split("\\[| ")[0])) {
-				if (!SBMLutilities.variableInUse(bioModel.getSBMLDocument(), ((String) compartments.getSelectedValue()).split("\\[| ")[0], false, true, true)) {
+				if (!SBMLutilities.variableInUse(bioModel.getSBMLDocument(), ((String) compartments.getSelectedValue()).split("\\[| ")[0], false, true, this, null)) {
 					Compartment tempComp = bioModel.getSBMLDocument().getModel().getCompartment(((String) compartments.getSelectedValue()).split("\\[| ")[0]);
 					ListOf<Compartment> c = bioModel.getSBMLDocument().getModel().getListOfCompartments();
 					for (int i = 0; i < bioModel.getSBMLDocument().getModel().getCompartmentCount(); i++) {

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/sbmlcore/Constraints.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/sbmlcore/Constraints.java
@@ -43,6 +43,7 @@ import org.sbml.jsbml.xml.XMLNode;
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.parser.BioModel;
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.util.SBMLutilities;
 import edu.utah.ece.async.ibiosim.dataModels.util.GlobalConstants;
+import edu.utah.ece.async.ibiosim.dataModels.util.observe.PanelObservable;
 import edu.utah.ece.async.ibiosim.gui.Gui;
 import edu.utah.ece.async.ibiosim.gui.modelEditor.schematic.ModelEditor;
 import edu.utah.ece.async.ibiosim.gui.modelEditor.schematic.Utils;
@@ -57,7 +58,7 @@ import edu.utah.ece.async.ibiosim.gui.util.Utility;
  * @author <a href="http://www.async.ece.utah.edu/ibiosim#Credits"> iBioSim Contributors </a>
  * @version %I%
  */
-public class Constraints extends JPanel implements ActionListener, MouseListener {
+public class Constraints extends PanelObservable implements ActionListener, MouseListener {
 
 	private static final long serialVersionUID = 1L;
 

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/sbmlcore/Events.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/sbmlcore/Events.java
@@ -42,6 +42,7 @@ import edu.utah.ece.async.ibiosim.dataModels.biomodel.annotation.AnnotationUtili
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.parser.BioModel;
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.util.SBMLutilities;
 import edu.utah.ece.async.ibiosim.dataModels.util.GlobalConstants;
+import edu.utah.ece.async.ibiosim.dataModels.util.observe.PanelObservable;
 import edu.utah.ece.async.ibiosim.gui.Gui;
 import edu.utah.ece.async.ibiosim.gui.modelEditor.schematic.ModelEditor;
 import edu.utah.ece.async.ibiosim.gui.modelEditor.schematic.Utils;
@@ -55,7 +56,7 @@ import edu.utah.ece.async.ibiosim.gui.util.Utility;
  * @author <a href="http://www.async.ece.utah.edu/ibiosim#Credits"> iBioSim Contributors </a>
  * @version %I%
  */
-public class Events extends JPanel implements ActionListener, MouseListener {
+public class Events extends PanelObservable implements ActionListener, MouseListener {
 
 	private static final long serialVersionUID = 1L;
 

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/sbmlcore/Functions.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/sbmlcore/Functions.java
@@ -47,6 +47,7 @@ import edu.utah.ece.async.ibiosim.dataModels.biomodel.parser.BioModel;
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.util.SBMLutilities;
 import edu.utah.ece.async.ibiosim.dataModels.util.GlobalConstants;
 import edu.utah.ece.async.ibiosim.dataModels.util.exceptions.BioSimException;
+import edu.utah.ece.async.ibiosim.dataModels.util.observe.PanelObservable;
 import edu.utah.ece.async.ibiosim.gui.Gui;
 import edu.utah.ece.async.ibiosim.gui.modelEditor.schematic.ModelEditor;
 import edu.utah.ece.async.ibiosim.gui.modelEditor.schematic.Utils;
@@ -63,7 +64,7 @@ import org.sbml.jsbml.JSBML;
  * @author <a href="http://www.async.ece.utah.edu/ibiosim#Credits"> iBioSim Contributors </a>
  * @version %I%
  */
-public class Functions extends JPanel implements ActionListener, MouseListener {
+public class Functions extends PanelObservable implements ActionListener, MouseListener {
 
 	private static final long serialVersionUID = 1L;
 
@@ -474,7 +475,7 @@ public class Functions extends JPanel implements ActionListener, MouseListener {
 	private void removeFunction() {
 		int index = functions.getSelectedIndex();
 		if (index != -1) {
-			if (!SBMLutilities.variableInUse(bioModel.getSBMLDocument(), ((String) functions.getSelectedValue()).split(" ")[0], false, true, true)) {
+			if (!SBMLutilities.variableInUse(bioModel.getSBMLDocument(), ((String) functions.getSelectedValue()).split(" ")[0], false, true, this, null)) {
 				FunctionDefinition tempFunc = bioModel.getSBMLDocument().getModel().getFunctionDefinition(((String) functions.getSelectedValue()).split(" ")[0]);
 				ListOf<FunctionDefinition> f = bioModel.getSBMLDocument().getModel().getListOfFunctionDefinitions();
 				for (int i = 0; i < bioModel.getSBMLDocument().getModel().getFunctionDefinitionCount(); i++) {

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/sbmlcore/MySpecies.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/sbmlcore/MySpecies.java
@@ -48,6 +48,7 @@ import edu.utah.ece.async.ibiosim.dataModels.biomodel.annotation.AnnotationUtili
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.parser.BioModel;
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.util.SBMLutilities;
 import edu.utah.ece.async.ibiosim.dataModels.util.exceptions.BioSimException;
+import edu.utah.ece.async.ibiosim.dataModels.util.observe.PanelObservable;
 import edu.utah.ece.async.ibiosim.gui.Gui;
 import edu.utah.ece.async.ibiosim.gui.modelEditor.schematic.ModelEditor;
 import edu.utah.ece.async.ibiosim.gui.modelEditor.schematic.Utils;
@@ -60,7 +61,7 @@ import edu.utah.ece.async.ibiosim.gui.util.Utility;
  * @author <a href="http://www.async.ece.utah.edu/ibiosim#Credits"> iBioSim Contributors </a>
  * @version %I%
  */
-public class MySpecies extends JPanel implements ActionListener, MouseListener {
+public class MySpecies extends PanelObservable implements ActionListener, MouseListener {
 
 	private static final long serialVersionUID = 1L;
 
@@ -442,6 +443,7 @@ public class MySpecies extends JPanel implements ActionListener, MouseListener {
 		speciesPanel.add(specHasOnly);
 		if (paramsOnly) {
 			JLabel typeLabel = new JLabel("Value Type:");
+			MySpecies instance = this;
 			type.addActionListener(new ActionListener() {
 				@Override
 				public void actionPerformed(ActionEvent e) {
@@ -456,7 +458,7 @@ public class MySpecies extends JPanel implements ActionListener, MouseListener {
 						initLabel.setEnabled(false);
 						SBMLDocument d;
             try {
-              d = SBMLutilities.readSBML(file);
+              d = SBMLutilities.readSBML(file, instance, null);
               if (d.getModel().getSpecies(((String) species.getSelectedValue()).split("\\[| ")[0]).isSetInitialAmount()) {
 							init.setText(d.getModel().getSpecies(((String) species.getSelectedValue()).split("\\[| ")[0]).getInitialAmount() + "");
 							initLabel.setSelectedItem("Initial Amount");
@@ -470,6 +472,11 @@ public class MySpecies extends JPanel implements ActionListener, MouseListener {
               e1.printStackTrace();
             } catch (IOException e1) {
               JOptionPane.showMessageDialog(Gui.frame, "I/O error when opening SBML file", "Error Opening File", JOptionPane.ERROR_MESSAGE);
+              e1.printStackTrace();
+            }
+            catch (BioSimException e1) {
+              JOptionPane.showMessageDialog(Gui.frame, e1.getMessage(), e1.getTitle(),
+                JOptionPane.ERROR_MESSAGE);
               e1.printStackTrace();
             }
 						
@@ -1047,7 +1054,7 @@ public class MySpecies extends JPanel implements ActionListener, MouseListener {
 				modelEditor.setDirty(true);
 				modelEditor.makeUndoPoint();
 			} else {
-				if (!SBMLutilities.variableInUse(bioModel.getSBMLDocument(), id, false, true, true)) {
+				if (!SBMLutilities.variableInUse(bioModel.getSBMLDocument(), id, false, true, this, null)) {
 				  modelEditor.removeSpecies(id);
 					modelEditor.setDirty(true);
 					modelEditor.makeUndoPoint();

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/sbmlcore/Parameters.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/sbmlcore/Parameters.java
@@ -40,6 +40,7 @@ import edu.utah.ece.async.ibiosim.dataModels.biomodel.parser.BioModel;
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.util.SBMLutilities;
 import edu.utah.ece.async.ibiosim.dataModels.util.GlobalConstants;
 import edu.utah.ece.async.ibiosim.dataModels.util.exceptions.BioSimException;
+import edu.utah.ece.async.ibiosim.dataModels.util.observe.PanelObservable;
 import edu.utah.ece.async.ibiosim.gui.Gui;
 import edu.utah.ece.async.ibiosim.gui.modelEditor.schematic.ModelEditor;
 import edu.utah.ece.async.ibiosim.gui.modelEditor.schematic.Utils;
@@ -63,7 +64,7 @@ import org.sbml.jsbml.UnitDefinition;
  * @author <a href="http://www.async.ece.utah.edu/ibiosim#Credits"> iBioSim Contributors </a>
  * @version %I%
  */
-public class Parameters extends JPanel implements ActionListener, MouseListener {
+public class Parameters extends PanelObservable implements ActionListener, MouseListener {
 
 	private static final long serialVersionUID = 1L;
 
@@ -545,6 +546,7 @@ public class Parameters extends JPanel implements ActionListener, MouseListener 
 		parametersPanel.add(paramName);
 		if (paramsOnly) {
 			JLabel typeLabel = new JLabel("Value Type:");
+			Parameters instance = this;
 			type.addActionListener(new ActionListener() {
 				@Override
 				public void actionPerformed(ActionEvent e) {
@@ -561,7 +563,7 @@ public class Parameters extends JPanel implements ActionListener, MouseListener 
 						paramUnits.setEnabled(false);
 						SBMLDocument d;
             try {
-              d = SBMLutilities.readSBML(file);
+              d = SBMLutilities.readSBML(file, instance, null);
               if (d.getModel().getParameter(((String) parameters.getSelectedValue()).split(" ")[0]).isSetValue()) {
                 paramValue.setText(d.getModel().getParameter(((String) parameters.getSelectedValue()).split(" ")[0]).getValue() + "");
               }
@@ -581,6 +583,11 @@ public class Parameters extends JPanel implements ActionListener, MouseListener 
               e1.printStackTrace();
             } catch (IOException e1) {
               JOptionPane.showMessageDialog(Gui.frame, "I/O error when opening SBML file", "Error Opening File", JOptionPane.ERROR_MESSAGE);
+              e1.printStackTrace();
+            }
+            catch (BioSimException e1) {
+              JOptionPane.showMessageDialog(Gui.frame, e1.getMessage(), e1.getTitle(),
+                JOptionPane.ERROR_MESSAGE);
               e1.printStackTrace();
             }
 						
@@ -983,7 +990,7 @@ public class Parameters extends JPanel implements ActionListener, MouseListener 
 	 * Remove a global parameter
 	 */
 	private boolean removeParameter(String selected) {
-		if (!SBMLutilities.variableInUse(bioModel.getSBMLDocument(), selected, false, true, true)) {
+		if (!SBMLutilities.variableInUse(bioModel.getSBMLDocument(), selected, false, true, this, null)) {
 			Parameter tempParameter = bioModel.getSBMLDocument().getModel().getParameter(selected);
 			ListOf<Parameter> p = bioModel.getSBMLDocument().getModel().getListOfParameters();
 			for (int i = 0; i < bioModel.getSBMLDocument().getModel().getParameterCount(); i++) {

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/sbmlcore/Reactions.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/sbmlcore/Reactions.java
@@ -57,6 +57,7 @@ import edu.utah.ece.async.ibiosim.dataModels.biomodel.parser.BioModel;
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.util.SBMLutilities;
 import edu.utah.ece.async.ibiosim.dataModels.util.GlobalConstants;
 import edu.utah.ece.async.ibiosim.dataModels.util.exceptions.BioSimException;
+import edu.utah.ece.async.ibiosim.dataModels.util.observe.PanelObservable;
 import edu.utah.ece.async.ibiosim.gui.Gui;
 import edu.utah.ece.async.ibiosim.gui.modelEditor.schematic.ModelEditor;
 import edu.utah.ece.async.ibiosim.gui.modelEditor.schematic.Utils;
@@ -70,7 +71,7 @@ import edu.utah.ece.async.ibiosim.gui.util.Utility;
  * @author <a href="http://www.async.ece.utah.edu/ibiosim#Credits"> iBioSim Contributors </a>
  * @version %I%
  */
-public class Reactions extends JPanel implements ActionListener, MouseListener {
+public class Reactions extends PanelObservable implements ActionListener, MouseListener {
 
 	private static final long serialVersionUID = 1L;
 
@@ -1496,6 +1497,7 @@ public class Reactions extends JPanel implements ActionListener, MouseListener {
 		parametersPanel.add(reacParamName);
 		if (paramsOnly) {
 			JLabel typeLabel = new JLabel("Value Type:");
+			Reactions instance=  this;
 			type.addActionListener(new ActionListener() {
 				@Override
 				public void actionPerformed(ActionEvent e) {
@@ -1512,7 +1514,7 @@ public class Reactions extends JPanel implements ActionListener, MouseListener {
 						SBOTerms.setEnabled(false);
 						SBMLDocument d;
             try {
-              d = SBMLutilities.readSBML(file);
+              d = SBMLutilities.readSBML(file, instance, null);
               KineticLaw KL = d.getModel().getReaction(selectedReaction).getKineticLaw();
               ListOf<LocalParameter> list = KL.getListOfLocalParameters();
               int number = -1;
@@ -1536,6 +1538,11 @@ public class Reactions extends JPanel implements ActionListener, MouseListener {
               e1.printStackTrace();
             } catch (IOException e1) {
               JOptionPane.showMessageDialog(Gui.frame, "I/O error when opening SBML file", "Error Opening File", JOptionPane.ERROR_MESSAGE);
+              e1.printStackTrace();
+            }
+            catch (BioSimException e1) {
+              JOptionPane.showMessageDialog(Gui.frame, e1.getMessage(), e1.getTitle(),
+                JOptionPane.ERROR_MESSAGE);
               e1.printStackTrace();
             }
 					}
@@ -1947,7 +1954,7 @@ public class Reactions extends JPanel implements ActionListener, MouseListener {
 				dimensionIds = SBMLutilities.getDimensionIds("p",dimID.length-1);
 				productID = dimID[0].trim();
 				if (productID.equals("")) {
-					error = SBMLutilities.variableInUse(bioModel.getSBMLDocument(), selectedID, false, true, true);
+					error = SBMLutilities.variableInUse(bioModel.getSBMLDocument(), selectedID, false, true, this, null);
 				}
 				else {
 					error = Utils.checkID(bioModel.getSBMLDocument(), productID, selectedID, false);
@@ -2380,7 +2387,7 @@ public class Reactions extends JPanel implements ActionListener, MouseListener {
 				modifierID = dimID[0].trim();
 				dimensionIds = SBMLutilities.getDimensionIds("m",dimID.length-1);
 				if (modifierID.equals("")) {
-					error = SBMLutilities.variableInUse(bioModel.getSBMLDocument(), selectedID, false, true, true);
+					error = SBMLutilities.variableInUse(bioModel.getSBMLDocument(), selectedID, false, true, this, null);
 				}
 				else {
 					error = Utils.checkID(bioModel.getSBMLDocument(), modifierID, selectedID, false);
@@ -2816,7 +2823,7 @@ public class Reactions extends JPanel implements ActionListener, MouseListener {
 				reactantID = dimID[0].trim();
 				dimensionIds = SBMLutilities.getDimensionIds("r",dimID.length-1);
 				if (reactantID.equals("")) {
-					error = SBMLutilities.variableInUse(gcm.getSBMLDocument(), selectedID, false, true, true);
+					error = SBMLutilities.variableInUse(gcm.getSBMLDocument(), selectedID, false, true, this, null);
 				}
 				else {
 					error = Utils.checkID(gcm.getSBMLDocument(), reactantID, selectedID, false);
@@ -3149,7 +3156,7 @@ public class Reactions extends JPanel implements ActionListener, MouseListener {
 			String v = ((String) reactants.getSelectedValue()).split("\\[| ")[0];
 			for (int i = 0; i < changedReactants.size(); i++) {
 				if ((changedReactants.get(i).getId().equals(v) || changedReactants.get(i).getSpecies().equals(v)) &&
-						!SBMLutilities.variableInUse(bioModel.getSBMLDocument(), changedReactants.get(i).getId(), false, true,true)) {
+						!SBMLutilities.variableInUse(bioModel.getSBMLDocument(), changedReactants.get(i).getId(), false, true, this, null)) {
 					changedReactants.remove(i);
 					reactants.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
 					reacta = (String[]) Utility.remove(reactants, reacta);
@@ -3176,7 +3183,7 @@ public class Reactions extends JPanel implements ActionListener, MouseListener {
 			String v = ((String) products.getSelectedValue()).split("\\[| ")[0];
 			for (int i = 0; i < changedProducts.size(); i++) {
 				if ((changedProducts.get(i).getId().equals(v) || changedProducts.get(i).getSpecies().equals(v)) && 
-						!SBMLutilities.variableInUse(bioModel.getSBMLDocument(), changedProducts.get(i).getId(), false, true, true)) {
+						!SBMLutilities.variableInUse(bioModel.getSBMLDocument(), changedProducts.get(i).getId(), false, true, this, null)) {
 					changedProducts.remove(i);
 					products.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
 					proda = (String[]) Utility.remove(products, proda);

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/sbmlcore/Rules.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/sbmlcore/Rules.java
@@ -408,7 +408,7 @@ public class Rules extends PanelObservable implements ActionListener, MouseListe
 						addStr = "0 = " + bioModel.removeBooleans(r.getMath());
 						try 
 						{
-              error = !Validate.validateDoc("",bioModel.getSBMLDocument(),true);
+              error = !Validate.validateDoc("",bioModel.getSBMLDocument(),true, this, null);
             } 
 						catch (SBMLException | IOException | XMLStreamException | BioSimException e) 
 						{
@@ -558,7 +558,7 @@ public class Rules extends PanelObservable implements ActionListener, MouseListe
 							r.setMath(bioModel.addBooleans(ruleMath.getText().trim()));
 							try 
 							{
-                error = !Validate.validateDoc("",bioModel.getSBMLDocument(),true);
+                error = !Validate.validateDoc("",bioModel.getSBMLDocument(),true, this, null);
               } 
 							catch (SBMLException | IOException | XMLStreamException | BioSimException e) {
                 error = true;

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/sbmlcore/Rules.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/sbmlcore/Rules.java
@@ -44,6 +44,8 @@ import edu.utah.ece.async.ibiosim.dataModels.biomodel.parser.BioModel;
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.util.SBMLutilities;
 import edu.utah.ece.async.ibiosim.dataModels.util.GlobalConstants;
 import edu.utah.ece.async.ibiosim.dataModels.util.Validate;
+import edu.utah.ece.async.ibiosim.dataModels.util.exceptions.BioSimException;
+import edu.utah.ece.async.ibiosim.dataModels.util.observe.PanelObservable;
 import edu.utah.ece.async.ibiosim.gui.Gui;
 import edu.utah.ece.async.ibiosim.gui.modelEditor.schematic.ModelEditor;
 import edu.utah.ece.async.ibiosim.gui.modelEditor.schematic.Utils;
@@ -72,7 +74,7 @@ import org.sbml.jsbml.SpeciesReference;
  * @author <a href="http://www.async.ece.utah.edu/ibiosim#Credits"> iBioSim Contributors </a>
  * @version %I%
  */
-public class Rules extends JPanel implements ActionListener, MouseListener {
+public class Rules extends PanelObservable implements ActionListener, MouseListener {
 
 	private static final long serialVersionUID = 1L;
 
@@ -408,7 +410,7 @@ public class Rules extends JPanel implements ActionListener, MouseListener {
 						{
               error = !Validate.validateDoc("",bioModel.getSBMLDocument(),true);
             } 
-						catch (SBMLException | IOException | XMLStreamException e) 
+						catch (SBMLException | IOException | XMLStreamException | BioSimException e) 
 						{
               error = true;
             }
@@ -558,7 +560,7 @@ public class Rules extends JPanel implements ActionListener, MouseListener {
 							{
                 error = !Validate.validateDoc("",bioModel.getSBMLDocument(),true);
               } 
-							catch (SBMLException | IOException | XMLStreamException e) {
+							catch (SBMLException | IOException | XMLStreamException | BioSimException e) {
                 error = true;
               }
 						}

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/sbmlcore/Units.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/sbmlcore/Units.java
@@ -44,6 +44,7 @@ import org.sbml.jsbml.ext.comp.Port;
 
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.parser.BioModel;
 import edu.utah.ece.async.ibiosim.dataModels.util.GlobalConstants;
+import edu.utah.ece.async.ibiosim.dataModels.util.observe.PanelObservable;
 import edu.utah.ece.async.ibiosim.gui.Gui;
 import edu.utah.ece.async.ibiosim.gui.modelEditor.schematic.ModelEditor;
 import edu.utah.ece.async.ibiosim.gui.modelEditor.schematic.Utils;
@@ -61,7 +62,7 @@ import org.sbml.jsbml.UnitDefinition;
  * @author <a href="http://www.async.ece.utah.edu/ibiosim#Credits"> iBioSim Contributors </a>
  * @version %I%
  */
-public class Units extends JPanel implements ActionListener, MouseListener {
+public class Units extends PanelObservable implements ActionListener, MouseListener {
 
 	private static final long serialVersionUID = 1L;
 

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/schematic/BioGraph.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/schematic/BioGraph.java
@@ -70,6 +70,7 @@ import edu.utah.ece.async.ibiosim.dataModels.biomodel.annotation.AnnotationUtili
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.parser.BioModel;
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.util.SBMLutilities;
 import edu.utah.ece.async.ibiosim.dataModels.util.GlobalConstants;
+import edu.utah.ece.async.ibiosim.dataModels.util.exceptions.BioSimException;
 import edu.utah.ece.async.ibiosim.gui.Gui;
 import edu.utah.ece.async.ibiosim.gui.ResourceManager;
 import edu.utah.ece.async.ibiosim.gui.modelEditor.comp.Grid;
@@ -1350,6 +1351,11 @@ public class BioGraph extends mxGraph {
         JOptionPane.showMessageDialog(Gui.frame, "I/O error when opening SBML file", "Error Opening File", JOptionPane.ERROR_MESSAGE);
         e.printStackTrace();
       }
+			catch (BioSimException e) {
+        JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+          JOptionPane.ERROR_MESSAGE);
+        e.printStackTrace();
+      }
 			HashMap<String,String> connections = bioModel.getInputConnections(compBioModel,id);
 			for (String propName : connections.keySet()) {
 				String targetName = connections.get(propName);
@@ -2306,6 +2312,11 @@ public class BioGraph extends mxGraph {
         e.printStackTrace();
       } catch (IOException e) {
         JOptionPane.showMessageDialog(Gui.frame, "I/O error when opening SBML file", "Error Opening File", JOptionPane.ERROR_MESSAGE);
+        e.printStackTrace();
+      }
+			catch (BioSimException e) {
+        JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+          JOptionPane.ERROR_MESSAGE);
         e.printStackTrace();
       }
 			compart = compBioModel.IsWithinCompartment();

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/schematic/BioGraph.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/schematic/BioGraph.java
@@ -1338,7 +1338,8 @@ public class BioGraph extends mxGraph {
 		// map components edges
 		for (int i = 0; i < bioModel.getSBMLCompModel().getListOfSubmodels().size(); i++) {
 			String id = bioModel.getSBMLCompModel().getListOfSubmodels().get(i).getId();
-			BioModel compBioModel = new BioModel(bioModel.getPath());
+			//BioModel compBioModel = BioModel.createBioModel(bioModel.getPath(), this);
+			BioModel compBioModel = BioModel.createBioModel(bioModel.getPath(), modelEditor);
 			String modelFileName = bioModel.getModelFileName(id);
 			try {
         compBioModel.load(bioModel.getPath() + File.separator + modelFileName);
@@ -2287,7 +2288,7 @@ public class BioGraph extends mxGraph {
 		boolean needsPositioning = false;
 				
 		//set the correct compartment status
-		BioModel compBioModel = new BioModel(bioModel.getPath());
+		BioModel compBioModel = BioModel.createBioModel(bioModel.getPath(), modelEditor);
 		boolean compart = false;
 		//String modelFileName = gcm.getModelFileName(id).replace(".xml", ".gcm");
 		String label = SBMLutilities.getArrayId(bioModel.getSBMLDocument(), id);

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/schematic/ModelEditor.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/schematic/ModelEditor.java
@@ -264,8 +264,7 @@ public class ModelEditor extends PanelObservable implements ActionListener, Mous
 			parameterChanges = new ArrayList<String>();
 			filename = refFile;
 		}
-		biomodel = new BioModel(path);
-		biomodel.addObservable(this);
+		biomodel =  BioModel.createBioModel(path, this);
 		if (filename != null) {
 			biomodel.load(path + File.separator + filename);
 			this.filename = filename;
@@ -811,7 +810,7 @@ public class ModelEditor extends PanelObservable implements ActionListener, Mous
 			try {
 				parser = new GCMParser(path + File.separator + modelId + ".xml");
 				GeneticNetwork network = null;
-				BioModel bioModel = new BioModel(path);
+				BioModel bioModel = BioModel.createBioModel(path, this);
 				bioModel.load(path + File.separator + modelId + ".xml");
 				SBMLDocument sbml = bioModel.flattenModel(true);
 				if (sbml == null)
@@ -2460,7 +2459,7 @@ public class ModelEditor extends PanelObservable implements ActionListener, Mous
 	public PromoterPanel launchPromoterPanel(String id) {
 		BioModel refGCM = null;
 		if (paramsOnly) {
-			refGCM = new BioModel(path);
+			refGCM =  BioModel.createBioModel(path, this);
 			try {
 				refGCM.load(path + File.separator + refFile);
 			} catch (XMLStreamException e) {
@@ -2498,7 +2497,7 @@ public class ModelEditor extends PanelObservable implements ActionListener, Mous
 		BioModel refGCM = null;
 
 		if (paramsOnly) {
-			refGCM = new BioModel(path);
+			refGCM =  BioModel.createBioModel(path, this);
 			try {
 				refGCM.load(path + File.separator + refFile);
 			} catch (XMLStreamException e) {
@@ -2536,7 +2535,7 @@ public class ModelEditor extends PanelObservable implements ActionListener, Mous
 	public InfluencePanel launchInfluencePanel(String id) {
 		BioModel refGCM = null;
 		if (paramsOnly) {
-			refGCM = new BioModel(path);
+			refGCM =  BioModel.createBioModel(path, this);
 			try {
 				refGCM.load(path + File.separator + refFile);
 			} catch (XMLStreamException e) {
@@ -2626,7 +2625,7 @@ public class ModelEditor extends PanelObservable implements ActionListener, Mous
 	public boolean checkNoComponentLoop(String gcm, String checkFile) {
 		gcm = gcm.replace(".gcm", ".xml");
 		boolean check = true;
-		BioModel g = new BioModel(path);
+		BioModel g = BioModel.createBioModel(path, this);
 		try {
 			g.load(path + File.separator + checkFile);
 		} catch (XMLStreamException e) {
@@ -2712,7 +2711,7 @@ public class ModelEditor extends PanelObservable implements ActionListener, Mous
 			}
 		}
 		if (comp != null && !comp.equals("")) {
-			BioModel subBioModel = new BioModel(path);
+			BioModel subBioModel = BioModel.createBioModel(path, this);
 			try {
 				subBioModel.load(path + File.separator + comp);
 				subBioModel.flattenBioModel();
@@ -3051,7 +3050,7 @@ public class ModelEditor extends PanelObservable implements ActionListener, Mous
 	 */
 	public boolean getGridEnabledFromFile(String filename) throws XMLStreamException, IOException {
 
-		BioModel subModel = new BioModel(path);
+		BioModel subModel =  BioModel.createBioModel(path, this);
 		subModel.load(filename);
 		if ((biomodel.getGridTable().getNumRows() > 0) || (subModel.getGridTable().getNumCols() > 0))
 			return true;

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/schematic/ModelEditor.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/schematic/ModelEditor.java
@@ -315,6 +315,11 @@ public class ModelEditor extends PanelObservable implements ActionListener, Mous
 					JOptionPane.ERROR_MESSAGE);
 			e.printStackTrace();
 		}
+		catch (BioSimException e) {
+      JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+        JOptionPane.ERROR_MESSAGE);
+      e.printStackTrace();
+    }
 	}
 
 	public void renameComponents(String oldname, String newName) {
@@ -453,6 +458,11 @@ public class ModelEditor extends PanelObservable implements ActionListener, Mous
 					JOptionPane.ERROR_MESSAGE);
 			e.printStackTrace();
 		}
+		catch (BioSimException e) {
+      JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+        JOptionPane.ERROR_MESSAGE);
+      e.printStackTrace();
+    }
 		log.addText("Saving SBML file:\n" + path + File.separator + modelId + ".xml");
 		// saveAsSBOL2();
 		// log.addText("Converting SBML into SBOL and saving into the project's
@@ -466,7 +476,7 @@ public class ModelEditor extends PanelObservable implements ActionListener, Mous
 
 	// Annotate SBML model with synthesized SBOL DNA component and save
 	// component to local SBOL file
-	public void saveSBOL2() throws SBOLValidationException {
+	public void saveSBOL2() throws SBOLValidationException, BioSimException {
 		try {
 			SBOLIdentityManager identityManager = new SBOLIdentityManager(biomodel,
 					Preferences.userRoot().get(SBOLEditorPreferences.INSTANCE.getUserInfo().getURI().toString(), ""));
@@ -790,6 +800,11 @@ public class ModelEditor extends PanelObservable implements ActionListener, Mous
 				log.addText("ERROR: Exporting SBML file:\n" + exportPath + "\n");
 				e.printStackTrace();
 			}
+			catch (BioSimException e) {
+        JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+          JOptionPane.ERROR_MESSAGE);
+        e.printStackTrace();
+      }
 		}
 	}
 
@@ -832,6 +847,11 @@ public class ModelEditor extends PanelObservable implements ActionListener, Mous
 				e.printStackTrace();
 				log.addText("ERROR: Exporting flat SBML file:\n" + exportPath + "failed.\n");
 			}
+			catch (BioSimException e) {
+        JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+          JOptionPane.ERROR_MESSAGE);
+        e.printStackTrace();
+      }
 		}
 	}
 
@@ -885,6 +905,11 @@ public class ModelEditor extends PanelObservable implements ActionListener, Mous
 					JOptionPane.ERROR_MESSAGE);
 			e.printStackTrace();
 		}
+		catch (BioSimException e) {
+      JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+        JOptionPane.ERROR_MESSAGE);
+      e.printStackTrace();
+    }
 		// biosim.updateTabName(modelId + ".xml", newName + ".xml");
 		// reload(newName);
 	}
@@ -918,6 +943,11 @@ public class ModelEditor extends PanelObservable implements ActionListener, Mous
 					JOptionPane.ERROR_MESSAGE);
 			e.printStackTrace();
 		}
+		catch (BioSimException e) {
+      JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+        JOptionPane.ERROR_MESSAGE);
+      e.printStackTrace();
+    }
 	}
 
 	/**
@@ -1741,6 +1771,12 @@ public class ModelEditor extends PanelObservable implements ActionListener, Mous
 				e.printStackTrace();
 				return false;
 			}
+			catch (BioSimException e) {
+        JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+          JOptionPane.ERROR_MESSAGE);
+        e.printStackTrace();
+        return false;
+      }
 			if (sbml == null) {
 				JOptionPane.showMessageDialog(Gui.frame, "Invalid XML in SBML file", "Error Checking File",
 						JOptionPane.ERROR_MESSAGE);
@@ -1810,6 +1846,11 @@ public class ModelEditor extends PanelObservable implements ActionListener, Mous
 						JOptionPane.ERROR_MESSAGE);
 				e.printStackTrace();
 			}
+			catch (BioSimException e) {
+        JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+          JOptionPane.ERROR_MESSAGE);
+        e.printStackTrace();
+      }
 		}
 		return true;
 	}
@@ -2471,6 +2512,11 @@ public class ModelEditor extends PanelObservable implements ActionListener, Mous
 						JOptionPane.ERROR_MESSAGE);
 				e.printStackTrace();
 			}
+			catch (BioSimException e) {
+        JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+          JOptionPane.ERROR_MESSAGE);
+        e.printStackTrace();
+      }
 		}
 		PromoterPanel panel = new PromoterPanel(id, biomodel, species, paramsOnly, refGCM, this);
 
@@ -2509,6 +2555,11 @@ public class ModelEditor extends PanelObservable implements ActionListener, Mous
 						JOptionPane.ERROR_MESSAGE);
 				e.printStackTrace();
 			}
+			catch (BioSimException e) {
+        JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+          JOptionPane.ERROR_MESSAGE);
+        e.printStackTrace();
+      }
 		}
 
 		SpeciesPanel panel = new SpeciesPanel(id, species, components, biomodel, paramsOnly, refGCM, this, inTab);
@@ -2547,6 +2598,11 @@ public class ModelEditor extends PanelObservable implements ActionListener, Mous
 						JOptionPane.ERROR_MESSAGE);
 				e.printStackTrace();
 			}
+			catch (BioSimException e) {
+        JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+          JOptionPane.ERROR_MESSAGE);
+        e.printStackTrace();
+      }
 		}
 		InfluencePanel panel = new InfluencePanel(id, biomodel, paramsOnly, refGCM, this);
 
@@ -2637,6 +2693,11 @@ public class ModelEditor extends PanelObservable implements ActionListener, Mous
 					JOptionPane.ERROR_MESSAGE);
 			e.printStackTrace();
 		}
+		catch (BioSimException e) {
+      JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+        JOptionPane.ERROR_MESSAGE);
+      e.printStackTrace();
+    }
 		for (int i = 0; i < g.getSBMLComp().getListOfExternalModelDefinitions().size(); i++) {
 			String compGCM = g.getSBMLComp().getListOfExternalModelDefinitions().get(i).getSource();
 			if (compGCM.equals(gcm)) {
@@ -2724,6 +2785,11 @@ public class ModelEditor extends PanelObservable implements ActionListener, Mous
 						JOptionPane.ERROR_MESSAGE);
 				e.printStackTrace();
 			}
+			catch (BioSimException e) {
+        JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+          JOptionPane.ERROR_MESSAGE);
+        e.printStackTrace();
+      }
 			String oldPort = null;
 			if (selected != null) {
 				oldPort = selected.substring(selected.split(" ")[0].length() + selected.split(" ")[1].length() + 2);
@@ -3047,8 +3113,9 @@ public class ModelEditor extends PanelObservable implements ActionListener, Mous
 	 * @return
 	 * @throws IOException
 	 * @throws XMLStreamException
+	 * @throws BioSimException 
 	 */
-	public boolean getGridEnabledFromFile(String filename) throws XMLStreamException, IOException {
+	public boolean getGridEnabledFromFile(String filename) throws XMLStreamException, IOException, BioSimException {
 
 		BioModel subModel =  BioModel.createBioModel(path, this);
 		subModel.load(filename);
@@ -3198,7 +3265,7 @@ public class ModelEditor extends PanelObservable implements ActionListener, Mous
 		}
 	}
 
-	public static boolean saveLPN(BioModel biomodel, String filename) throws XMLStreamException, IOException {
+	public static boolean saveLPN(BioModel biomodel, String filename) throws XMLStreamException, IOException, BioSimException {
 		SBMLDocument sbml = biomodel.getSBMLDocument();
 		HashMap<String, Integer> constants = new HashMap<String, Integer>();
 		ArrayList<String> booleans = new ArrayList<String>();

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/schematic/ModelEditor.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/schematic/ModelEditor.java
@@ -468,7 +468,7 @@ public class ModelEditor extends PanelObservable implements ActionListener, Mous
 		// log.addText("Converting SBML into SBOL and saving into the project's
 		// SBOL library.");
 		if (check) {
-			Utils.check(path + File.separator + modelId + ".xml", biomodel.getSBMLDocument(), false);
+			Utils.check(path + File.separator + modelId + ".xml", biomodel.getSBMLDocument(), false, this, null);
 		}
 		biosim.updateViews(modelId + ".xml");
 

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/schematic/ModelEditor.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/schematic/ModelEditor.java
@@ -2143,15 +2143,35 @@ public class ModelEditor extends PanelObservable implements ActionListener, Mous
 
 		compartmentPanel = new Compartments(biomodel, this, paramsOnly, getParams, path + File.separator + file,
 				parameterChanges, false);
+		compartmentPanel.addObservable(this);
+		
 		reactionPanel = new Reactions(biomodel, paramsOnly, getParams, path + File.separator + file, parameterChanges, this);
+		reactionPanel.addObservable(this);
+		
 		speciesPanel = new MySpecies(biomodel, paramsOnly, getParams, path + File.separator + file, parameterChanges,
 		  biomodel.isGridEnabled(), this);
+		speciesPanel.addObservable(this);
+		
 		parametersPanel = new Parameters(biomodel, this, paramsOnly, getParams, path + File.separator + file,
 				parameterChanges, (paramsOnly || !textBased) && !biomodel.isGridEnabled());
+		parametersPanel.addObservable(this);
+    
 		rulesPanel = new Rules(biomodel, this);
+		rulesPanel.addObservable(this);
+		
 		consPanel = new Constraints(biomodel, this);
+		consPanel.addObservable(this);
+    
 		eventPanel = new Events(biosim, biomodel, this, textBased, lema);
+		eventPanel.addObservable(this);
 
+
+    functionPanel = new Functions(biomodel, this);
+    functionPanel.addObservable(this);
+    
+    unitPanel = new Units(biomodel, this);
+    unitPanel.addObservable(this);
+    
 		JPanel compPanel = new JPanel(new BorderLayout());
 		if (textBased) {
 			modelPanel = new ModelPanel(biomodel, this);
@@ -2181,6 +2201,8 @@ public class ModelEditor extends PanelObservable implements ActionListener, Mous
 
 		this.schematic = new Schematic(biomodel, biosim, this, true, null, compartmentPanel, reactionPanel, rulesPanel,
 				consPanel, eventPanel, parametersPanel, lema);
+		schematic.addObservable(this);
+		
 		int size = SBMLutilities.getModelSize(biomodel.getSBMLDocument());
 		if (!textBased && size > LARGE_MODEL_SIZE) {
 			String[] editor = { "Open in Textual Editor", "Open in Graphical Editor" };
@@ -2220,8 +2242,6 @@ public class ModelEditor extends PanelObservable implements ActionListener, Mous
 
 		}
 
-		functionPanel = new Functions(biomodel, this);
-		unitPanel = new Units(biomodel, this);
 		// JPanel defnPanel = new JPanel(new BorderLayout());
 		// defnPanel.add(mainPanelNorth, "North");
 		// defnPanel.add(functionPanel,"Center");

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/schematic/Schematic.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/schematic/Schematic.java
@@ -104,6 +104,7 @@ import edu.utah.ece.async.ibiosim.dataModels.biomodel.annotation.AnnotationUtili
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.parser.BioModel;
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.util.SBMLutilities;
 import edu.utah.ece.async.ibiosim.dataModels.util.GlobalConstants;
+import edu.utah.ece.async.ibiosim.dataModels.util.exceptions.BioSimException;
 import edu.utah.ece.async.ibiosim.dataModels.util.observe.PanelObservable;
 import edu.utah.ece.async.ibiosim.gui.Gui;
 import edu.utah.ece.async.ibiosim.gui.ResourceManager;
@@ -1401,25 +1402,25 @@ public class Schematic extends PanelObservable implements ActionListener {
 				String type = graph.getCellType(cell);
 
 				if(type == GlobalConstants.SPECIES){
-					if (SBMLutilities.variableInUse(bioModel.getSBMLDocument(), cell.getId(), false, true, true)) {
+					if (SBMLutilities.variableInUse(bioModel.getSBMLDocument(), cell.getId(), false, true, this, null)) {
 						doNotRemove = true;
 					}
 				} else if (type == GlobalConstants.PROMOTER){
-					if (SBMLutilities.variableInUse(bioModel.getSBMLDocument(), cell.getId(), false, true, false)) {
+					if (SBMLutilities.variableInUse(bioModel.getSBMLDocument(), cell.getId(), false, false, this, null)) {
 						doNotRemove = true;
 					}
 				} else if(type == GlobalConstants.VARIABLE || type == GlobalConstants.PLACE || type == GlobalConstants.BOOLEAN) {
-					if (SBMLutilities.variableInUse(bioModel.getSBMLDocument(), cell.getId(), false, true, true)) {
+					if (SBMLutilities.variableInUse(bioModel.getSBMLDocument(), cell.getId(), false, true, this, null)) {
 						doNotRemove = true;
 					}
 				} else if(type == GlobalConstants.COMPARTMENT) {
 					if (Utils.compartmentInUse(bioModel.getSBMLDocument(), cell.getId())) {
 						doNotRemove = true; 
-					} else if (SBMLutilities.variableInUse(bioModel.getSBMLDocument(), cell.getId(), false, true, true)) {
+					} else if (SBMLutilities.variableInUse(bioModel.getSBMLDocument(), cell.getId(), false, true, this, null)) {
 						doNotRemove = true;
 					}
 				} else if (type == GlobalConstants.REACTION){
-					if (SBMLutilities.variableInUse(bioModel.getSBMLDocument(), cell.getId(), false, true, false)) {
+					if (SBMLutilities.variableInUse(bioModel.getSBMLDocument(), cell.getId(), false, false, this, null)) {
 						doNotRemove = true;
 					}
 					/*
@@ -1441,7 +1442,7 @@ public class Schematic extends PanelObservable implements ActionListener {
 							SpeciesReference s = reactants.get(i);
 							if (s.getSpecies().equals(source.getId())) {
 								if (s.isSetId() && 
-										SBMLutilities.variableInUse(bioModel.getSBMLDocument(), s.getId(), false, true, false)) {
+										SBMLutilities.variableInUse(bioModel.getSBMLDocument(), s.getId(), false, false, this, null)) {
 									doNotRemove = true;
 								}
 								break;
@@ -1452,7 +1453,7 @@ public class Schematic extends PanelObservable implements ActionListener {
 							SpeciesReference s = products.get(i);
 							if (s.getSpecies().equals(target.getId())) {
 								if (s.isSetId() && 
-										SBMLutilities.variableInUse(bioModel.getSBMLDocument(), s.getId(), false, true, false)) {
+										SBMLutilities.variableInUse(bioModel.getSBMLDocument(), s.getId(), false, false, this, null)) {
 									doNotRemove = true;
 								}
 								break;
@@ -1465,7 +1466,7 @@ public class Schematic extends PanelObservable implements ActionListener {
 						int reactantNum = Integer.parseInt(cell.getId().replace(source.getId()+"__r","").replace("__"+target.getId(),""));
 						SpeciesReference s = r.getReactant(reactantNum);
 						if (s.isSetId() && 
-								SBMLutilities.variableInUse(bioModel.getSBMLDocument(), s.getId(), false, true, false)) {
+								SBMLutilities.variableInUse(bioModel.getSBMLDocument(), s.getId(), false, false, this, null)) {
 							doNotRemove = true;
 						}
 						break;
@@ -1476,7 +1477,7 @@ public class Schematic extends PanelObservable implements ActionListener {
 						int productNum = Integer.parseInt(cell.getId().replace(source.getId()+"__p","").replace("__"+target.getId(),""));
 						SpeciesReference s = r.getProduct(productNum);
 						if (s.isSetId() && 
-								SBMLutilities.variableInUse(bioModel.getSBMLDocument(), s.getId(), false, true, false)) {
+								SBMLutilities.variableInUse(bioModel.getSBMLDocument(), s.getId(), false, false, this, null)) {
 							doNotRemove = true;
 						}
 						break;
@@ -1488,7 +1489,7 @@ public class Schematic extends PanelObservable implements ActionListener {
 					int modifierNum = Integer.parseInt(cell.getId().replace(source.getId()+"__m","").replace("__"+target.getId(),""));
 					ModifierSpeciesReference s = r.getModifier(modifierNum);
 					if (s.isSetId() && 
-							SBMLutilities.variableInUse(bioModel.getSBMLDocument(), s.getId(), false, true, false)) {
+							SBMLutilities.variableInUse(bioModel.getSBMLDocument(), s.getId(), false, false, this, null)) {
 						doNotRemove = true;
 					}
 					break;
@@ -2144,6 +2145,11 @@ public class Schematic extends PanelObservable implements ActionListener {
       JOptionPane.showMessageDialog(Gui.frame, "I/O error when opening SBML file", "Error Opening File", JOptionPane.ERROR_MESSAGE);
       e.printStackTrace();
     }
+		catch (BioSimException e) {
+      JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+        JOptionPane.ERROR_MESSAGE);
+      e.printStackTrace();
+    }
 		return null;
 	}
 	
@@ -2169,6 +2175,11 @@ public class Schematic extends PanelObservable implements ActionListener {
       e.printStackTrace();
     } catch (IOException e) {
       JOptionPane.showMessageDialog(Gui.frame, "I/O error when opening SBML file", "Error Opening File", JOptionPane.ERROR_MESSAGE);
+      e.printStackTrace();
+    }
+		catch (BioSimException e) {
+      JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+        JOptionPane.ERROR_MESSAGE);
       e.printStackTrace();
     }
 		return null;
@@ -2206,6 +2217,11 @@ public class Schematic extends PanelObservable implements ActionListener {
       JOptionPane.showMessageDialog(Gui.frame, "I/O error when opening SBML file", "Error Opening File", JOptionPane.ERROR_MESSAGE);
       e.printStackTrace();
     }
+		catch (BioSimException e) {
+      JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+        JOptionPane.ERROR_MESSAGE);
+      e.printStackTrace();
+    }
 	  return null;
 	}
 	
@@ -2239,6 +2255,11 @@ public class Schematic extends PanelObservable implements ActionListener {
       e.printStackTrace();
     } catch (IOException e) {
       JOptionPane.showMessageDialog(Gui.frame, "I/O error when opening SBML file", "Error Opening File", JOptionPane.ERROR_MESSAGE);
+      e.printStackTrace();
+    }
+		catch (BioSimException e) {
+      JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+        JOptionPane.ERROR_MESSAGE);
       e.printStackTrace();
     }
 		return null;
@@ -2620,6 +2641,11 @@ public class Schematic extends PanelObservable implements ActionListener {
 		          JOptionPane.showMessageDialog(Gui.frame, "I/O error when opening SBML file", "Error Opening File", JOptionPane.ERROR_MESSAGE);
 		          e.printStackTrace();
 		        }
+						catch (BioSimException e) {
+			        JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+			          JOptionPane.ERROR_MESSAGE);
+			        e.printStackTrace();
+			      }
 						
 						break;						
 					}

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/schematic/Schematic.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/schematic/Schematic.java
@@ -104,6 +104,7 @@ import edu.utah.ece.async.ibiosim.dataModels.biomodel.annotation.AnnotationUtili
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.parser.BioModel;
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.util.SBMLutilities;
 import edu.utah.ece.async.ibiosim.dataModels.util.GlobalConstants;
+import edu.utah.ece.async.ibiosim.dataModels.util.observe.PanelObservable;
 import edu.utah.ece.async.ibiosim.gui.Gui;
 import edu.utah.ece.async.ibiosim.gui.ResourceManager;
 import edu.utah.ece.async.ibiosim.gui.modelEditor.comp.DropComponentPanel;
@@ -126,7 +127,7 @@ import edu.utah.ece.async.ibiosim.gui.modelEditor.sbmlcore.SpeciesPanel;
  * @author <a href="http://www.async.ece.utah.edu/ibiosim#Credits"> iBioSim Contributors </a>
  * @version %I%
  */
-public class Schematic extends JPanel implements ActionListener {
+public class Schematic extends PanelObservable implements ActionListener {
 		
 	//CLASS VARIABLES
 	
@@ -2127,7 +2128,7 @@ public class Schematic extends JPanel implements ActionListener {
 	 */
 	public String connectComponentToSpecies(String compID, String specID) throws ListChooser.EmptyListException{
 		String fullPath = bioModel.getPath() + File.separator + bioModel.getModelFileName(compID);
-		BioModel compBioModel = new BioModel(bioModel.getPath());
+		BioModel compBioModel = BioModel.createBioModel(bioModel.getPath(), this);
 		try {
       compBioModel.load(fullPath);
 		ArrayList<String> ports = compBioModel.getOutputPorts(GlobalConstants.SBMLSPECIES);
@@ -2154,7 +2155,7 @@ public class Schematic extends JPanel implements ActionListener {
 	 */
 	public String connectSpeciesToComponent(String specID, String compID) throws ListChooser.EmptyListException{
 		String fullPath = bioModel.getPath() + File.separator + bioModel.getModelFileName(compID);
-		BioModel compBioModel = new BioModel(bioModel.getPath());
+		BioModel compBioModel = BioModel.createBioModel(bioModel.getPath(), this);
 		try {
       compBioModel.load(fullPath);
       ArrayList<String> ports = compBioModel.getInputPorts(GlobalConstants.SBMLSPECIES);
@@ -2182,7 +2183,7 @@ public class Schematic extends JPanel implements ActionListener {
 	public String connectComponentToVariable(String compID, String varID) throws ListChooser.EmptyListException{
 		Parameter p = bioModel.getSBMLDocument().getModel().getParameter(varID);
 		String fullPath = bioModel.getPath() + File.separator + bioModel.getModelFileName(compID);
-		BioModel compBioModel = new BioModel(bioModel.getPath());
+		BioModel compBioModel = BioModel.createBioModel(bioModel.getPath(), this);
 		try {
       compBioModel.load(fullPath);
       ArrayList<String> ports;
@@ -2217,7 +2218,7 @@ public class Schematic extends JPanel implements ActionListener {
 	public String connectVariableToComponent(String varID, String compID) throws ListChooser.EmptyListException{
 		Parameter p = bioModel.getSBMLDocument().getModel().getParameter(varID);
 		String fullPath = bioModel.getPath() + File.separator + bioModel.getModelFileName(compID);
-		BioModel compBioModel = new BioModel(bioModel.getPath());
+		BioModel compBioModel = BioModel.createBioModel(bioModel.getPath(), this);
 		try {
       compBioModel.load(fullPath);
       ArrayList<String> ports;
@@ -2602,7 +2603,7 @@ public class Schematic extends JPanel implements ActionListener {
 						
 						String s = bioModel.getSBMLCompModel().getListOfSubmodels().get(i).getId();
 						
-						BioModel subModel = new BioModel(bioModel.getPath());
+						BioModel subModel = BioModel.createBioModel(bioModel.getPath(), this);
 						String extModel = bioModel.getSBMLComp().getListOfExternalModelDefinitions().get(bioModel.getSBMLCompModel().getListOfSubmodels().get(s)
 									.getModelRef()).getSource().replace("file://","").replace("file:","").replace(".gcm",".xml");
 						try {

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/schematic/Utils.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/schematic/Utils.java
@@ -65,6 +65,8 @@ import edu.utah.ece.async.ibiosim.dataModels.biomodel.util.Utility;
 import edu.utah.ece.async.ibiosim.dataModels.util.Executables;
 import edu.utah.ece.async.ibiosim.dataModels.util.Validate;
 import edu.utah.ece.async.ibiosim.dataModels.util.exceptions.BioSimException;
+import edu.utah.ece.async.ibiosim.dataModels.util.observe.BioObservable;
+import edu.utah.ece.async.ibiosim.dataModels.util.observe.BioObserver;
 import edu.utah.ece.async.ibiosim.gui.Gui;
 
 /**
@@ -701,22 +703,11 @@ public class Utils {
   /**
    * Checks consistency of the sbml file.
    */
-  public static void check(String file, SBMLDocument doc, boolean overdeterminedOnly)
+  public static void check(String file, SBMLDocument doc, boolean overdeterminedOnly, BioObservable observable, BioObserver observer)
   {
     try 
     {
-      if(Validate.validateDoc(file, doc, overdeterminedOnly))
-      {
-        String message = Validate.getMessage();
-        JTextArea messageArea = new JTextArea(message);
-        messageArea.setLineWrap(true);
-        messageArea.setEditable(false);
-        JScrollPane scroll = new JScrollPane();
-        scroll.setMinimumSize(new java.awt.Dimension(600, 600));
-        scroll.setPreferredSize(new java.awt.Dimension(600, 600));
-        scroll.setViewportView(messageArea);
-        JOptionPane.showMessageDialog(Gui.frame, scroll, "SBML Errors and Warnings", JOptionPane.ERROR_MESSAGE);
-      }
+      Validate.validateDoc(file, doc, overdeterminedOnly, observable, observer);
     } catch (SBMLException e) {
       JOptionPane.showMessageDialog(Gui.frame, "Invalid SBML file", "Error Checking File", JOptionPane.ERROR_MESSAGE);
     } catch (IOException e) {

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/schematic/Utils.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/schematic/Utils.java
@@ -64,6 +64,7 @@ import edu.utah.ece.async.ibiosim.dataModels.biomodel.util.SBMLutilities;
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.util.Utility;
 import edu.utah.ece.async.ibiosim.dataModels.util.Executables;
 import edu.utah.ece.async.ibiosim.dataModels.util.Validate;
+import edu.utah.ece.async.ibiosim.dataModels.util.exceptions.BioSimException;
 import edu.utah.ece.async.ibiosim.gui.Gui;
 
 /**
@@ -722,6 +723,11 @@ public class Utils {
       JOptionPane.showMessageDialog(Gui.frame, "I/O error when opening SBML file", "Error Opening File", JOptionPane.ERROR_MESSAGE);
     } catch (XMLStreamException e) {
       JOptionPane.showMessageDialog(Gui.frame, "Invalid XML in SBML file", "Error Checking File", JOptionPane.ERROR_MESSAGE);
+      e.printStackTrace();
+    }
+    catch (BioSimException e) {
+      JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+        JOptionPane.ERROR_MESSAGE);
       e.printStackTrace();
     }
     

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/synthesisView/SynthesisView.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/synthesisView/SynthesisView.java
@@ -52,6 +52,7 @@ import edu.utah.ece.async.ibiosim.dataModels.biomodel.parser.BioModel;
 import edu.utah.ece.async.ibiosim.dataModels.sbol.SBOLFileManager;
 import edu.utah.ece.async.ibiosim.dataModels.util.GlobalConstants;
 import edu.utah.ece.async.ibiosim.dataModels.util.IBioSimPreferences;
+import edu.utah.ece.async.ibiosim.dataModels.util.exceptions.BioSimException;
 import edu.utah.ece.async.ibiosim.dataModels.util.exceptions.SBOLException;
 import edu.utah.ece.async.ibiosim.gui.Gui;
 import edu.utah.ece.async.ibiosim.gui.util.Log;
@@ -396,6 +397,11 @@ public class SynthesisView extends JTabbedPane implements ActionListener, Runnab
 								JOptionPane.showMessageDialog(Gui.frame, "Invalid XML in SBML file", "Error Checking File", JOptionPane.ERROR_MESSAGE);
 								e.printStackTrace();
 							}
+							catch (BioSimException e) {
+				        JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+				          JOptionPane.ERROR_MESSAGE);
+				        e.printStackTrace();
+				      }
 							graphlibrary.add(new SynthesisGraph(gateModel, fileManager));
 						}
 
@@ -408,6 +414,11 @@ public class SynthesisView extends JTabbedPane implements ActionListener, Runnab
 					JOptionPane.showMessageDialog(Gui.frame, "Invalid XML in SBML file", "Error Checking File", JOptionPane.ERROR_MESSAGE);
 					e.printStackTrace();
 				} 
+				catch (BioSimException e) {
+	        JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+	          JOptionPane.ERROR_MESSAGE);
+	        e.printStackTrace();
+	      }
 				SynthesisGraph spec = new SynthesisGraph(specModel, fileManager); //NOTE: load the SBML library file
 
 				//NOTE: set up library to match with the given biomodel
@@ -467,6 +478,11 @@ public class SynthesisView extends JTabbedPane implements ActionListener, Runnab
 				JOptionPane.showMessageDialog(Gui.frame, "I/O error when opening SBML file", "Error Opening File", JOptionPane.ERROR_MESSAGE);
 				e.printStackTrace();
 			}
+			catch (BioSimException e) {
+        JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+          JOptionPane.ERROR_MESSAGE);
+        e.printStackTrace();
+      }
 			solutionModels.add(solutionModel);
 		}
 		List<String> orderedSolnFileIDs = new LinkedList<String>();
@@ -487,6 +503,11 @@ public class SynthesisView extends JTabbedPane implements ActionListener, Runnab
 				JOptionPane.showMessageDialog(Gui.frame, "I/O error when opening SBML file", "Error Opening File", JOptionPane.ERROR_MESSAGE);
 				e.printStackTrace();
 			}
+			catch (BioSimException e) {
+        JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+          JOptionPane.ERROR_MESSAGE);
+        e.printStackTrace();
+      }
 			orderedSolnFileIDs.add(solutionID + "_" + idIndex + ".xml");
 		}
 		orderedSolnFileIDs.addAll(solutionFileIDs);
@@ -508,6 +529,11 @@ public class SynthesisView extends JTabbedPane implements ActionListener, Runnab
 				JOptionPane.showMessageDialog(Gui.frame, "I/O error when opening SBML file", "Error Opening File", JOptionPane.ERROR_MESSAGE);
 				e.printStackTrace();
 			}
+			catch (BioSimException e) {
+        JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+          JOptionPane.ERROR_MESSAGE);
+        e.printStackTrace();
+      }
 			if (solutionFileToGraph.containsKey(solutionGraph.getModelFileID())) {
 				SynthesisGraph clashingGraph = solutionFileToGraph.get(solutionGraph.getModelFileID());
 				BioModel clashingSubModel = new BioModel(clashingGraph.getProjectPath());
@@ -520,6 +546,11 @@ public class SynthesisView extends JTabbedPane implements ActionListener, Runnab
 					JOptionPane.showMessageDialog(Gui.frame, "I/O error when opening SBML file", "Error Opening File", JOptionPane.ERROR_MESSAGE);
 					e.printStackTrace();
 				}
+				catch (BioSimException e) {
+	        JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+	          JOptionPane.ERROR_MESSAGE);
+	        e.printStackTrace();
+	      }
 				if (!compareModels(solutionSubModel, clashingSubModel)) {
 					clashingFileIDs.add(solutionGraph.getModelFileID());
 					solutionFileToGraph.remove(solutionGraph.getModelFileID());
@@ -550,6 +581,11 @@ public class SynthesisView extends JTabbedPane implements ActionListener, Runnab
 			JOptionPane.showMessageDialog(Gui.frame, "I/O error when opening SBML file", "Error Opening File", JOptionPane.ERROR_MESSAGE);
 			e.printStackTrace();
 		}
+		catch (BioSimException e) {
+      JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+        JOptionPane.ERROR_MESSAGE);
+      e.printStackTrace();
+    }
 		return solutionFileToGraph.keySet();
 	}
 

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/util/FileTree.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/util/FileTree.java
@@ -32,6 +32,7 @@ import edu.utah.ece.async.ibiosim.dataModels.biomodel.parser.BioModel;
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.parser.GCM2SBML;
 import edu.utah.ece.async.ibiosim.dataModels.sbol.SBOLUtility;
 import edu.utah.ece.async.ibiosim.dataModels.util.GlobalConstants;
+import edu.utah.ece.async.ibiosim.dataModels.util.exceptions.BioSimException;
 import edu.utah.ece.async.ibiosim.dataModels.util.observe.PanelObservable;
 import edu.utah.ece.async.ibiosim.gui.Gui;
 import edu.utah.ece.async.ibiosim.gui.ResourceManager;
@@ -358,6 +359,11 @@ public class FileTree extends PanelObservable implements MouseListener {
 					JOptionPane.showMessageDialog(Gui.frame, "I/O error when opening SBML file", "Error Opening File", JOptionPane.ERROR_MESSAGE);
 					e.printStackTrace();
 				}
+				catch (BioSimException e) {
+	        JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+	          JOptionPane.ERROR_MESSAGE);
+	        e.printStackTrace();
+	      }
 
 			}
 			else {

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/util/FileTree.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/util/FileTree.java
@@ -32,6 +32,7 @@ import edu.utah.ece.async.ibiosim.dataModels.biomodel.parser.BioModel;
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.parser.GCM2SBML;
 import edu.utah.ece.async.ibiosim.dataModels.sbol.SBOLUtility;
 import edu.utah.ece.async.ibiosim.dataModels.util.GlobalConstants;
+import edu.utah.ece.async.ibiosim.dataModels.util.observe.PanelObservable;
 import edu.utah.ece.async.ibiosim.gui.Gui;
 import edu.utah.ece.async.ibiosim.gui.ResourceManager;
 
@@ -43,7 +44,7 @@ import edu.utah.ece.async.ibiosim.gui.ResourceManager;
  * @author <a href="http://www.async.ece.utah.edu/ibiosim#Credits"> iBioSim Contributors </a>
  * @version %I%
  */
-public class FileTree extends JPanel implements MouseListener {
+public class FileTree extends PanelObservable implements MouseListener {
 
 	private static final long serialVersionUID = -6799125543270861304L;
 
@@ -341,7 +342,7 @@ public class FileTree extends JPanel implements MouseListener {
 				}
 			if (!async && thisObject.toString().endsWith(".gcm")) {
 				String sbmlFile = thisObject.replace(".gcm",".xml");
-				BioModel bioModel = new BioModel(curPath);
+				BioModel bioModel =  BioModel.createBioModel(curPath, this);
 				try {
 					bioModel.load(curPath + File.separator + sbmlFile);
 					GCM2SBML gcm2sbml = new GCM2SBML(bioModel);

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/verificationView/VerificationView.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/verificationView/VerificationView.java
@@ -3113,6 +3113,11 @@ public class VerificationView extends PanelObservable implements ActionListener,
         JOptionPane.showMessageDialog(Gui.frame, "I/O error when opening SBML file", "Error Opening File", JOptionPane.ERROR_MESSAGE);
         e.printStackTrace();
       }
+			catch (BioSimException e) {
+        JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+          JOptionPane.ERROR_MESSAGE);
+        e.printStackTrace();
+      }
 			
 		}
 	}

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/verificationView/VerificationView.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/verificationView/VerificationView.java
@@ -3102,7 +3102,7 @@ public class VerificationView extends PanelObservable implements ActionListener,
 				//e.printStackTrace();
 			}
 		} else if (sourceFile.endsWith(".xml")) {
-			BioModel bioModel = new BioModel(workDir);
+			BioModel bioModel =  BioModel.createBioModel(workDir, this);
 			try {
         bioModel.load(workDir + File.separator + sourceFile);
         ModelEditor.saveLPN(bioModel, directory + File.separator + sourceFile.replace(".xml", ".lpn"));

--- a/learn/src/main/java/edu/utah/ece/async/ibiosim/learn/Learn.java
+++ b/learn/src/main/java/edu/utah/ece/async/ibiosim/learn/Learn.java
@@ -161,7 +161,6 @@ public class Learn implements BioObserver
 
   public static void main(String[] args) 
   {
-
     if(args.length  < 2)
     {
       usage();

--- a/learn/src/main/java/edu/utah/ece/async/ibiosim/learn/Learn.java
+++ b/learn/src/main/java/edu/utah/ece/async/ibiosim/learn/Learn.java
@@ -472,7 +472,7 @@ public class Learn implements BioObserver
         
         if(new File(learnFile).exists())
         {
-          BioModel biomodel = new BioModel(directory);
+          BioModel biomodel =  BioModel.createBioModel(directory, this);
           biomodel.load(learnFile);
           GCM2SBML gcm2sbml = new GCM2SBML(biomodel);
           gcm2sbml.load(learnFile);

--- a/learn/src/main/java/edu/utah/ece/async/ibiosim/learn/Learn.java
+++ b/learn/src/main/java/edu/utah/ece/async/ibiosim/learn/Learn.java
@@ -456,7 +456,7 @@ public class Learn implements BioObserver
     
   }
 
-  private void saveSBML(SBMLDocument doc) throws XMLStreamException, IOException
+  private void saveSBML(SBMLDocument doc) throws XMLStreamException, IOException, BioSimException
   {
     if(sbmlOut != null)
     {
@@ -654,13 +654,14 @@ public class Learn implements BioObserver
    * 
    * @throws XMLStreamException - when reading bad formatted sbml file
    * @throws IOException - when something wrong happens when saving the background file.
+   * @throws BioSimException - when the SBML file is invalid. 
    */
-  public static List<String> writeBackgroundFile(String learnFile, String directory) throws XMLStreamException, IOException
+  public static List<String> writeBackgroundFile(String learnFile, String directory) throws XMLStreamException, IOException, BioSimException
   {
     ArrayList<String> speciesList = new ArrayList<String>();
     if ((learnFile.contains(".sbml")) || (learnFile.contains(".xml")))
     {
-      SBMLDocument document = SBMLutilities.readSBML(learnFile);
+      SBMLDocument document = SBMLutilities.readSBML(learnFile, null, null);
       Model model = document.getModel();
       FileWriter write = new FileWriter(new File(directory + File.separator + "background.gcm"));
       write.write("digraph G {\n");

--- a/synthesis/src/main/java/edu/utah/ece/async/ibiosim/synthesis/SBMLTechMapping/Synthesizer.java
+++ b/synthesis/src/main/java/edu/utah/ece/async/ibiosim/synthesis/SBMLTechMapping/Synthesizer.java
@@ -32,6 +32,7 @@ import edu.utah.ece.async.ibiosim.dataModels.biomodel.parser.BioModel;
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.util.SBMLutilities;
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.util.Utility;
 import edu.utah.ece.async.ibiosim.dataModels.util.GlobalConstants;
+import edu.utah.ece.async.ibiosim.dataModels.util.exceptions.BioSimException;
 
 import org.sbml.jsbml.SBase;
 import org.sbml.jsbml.Species;
@@ -241,7 +242,7 @@ public class Synthesizer {
 			specNodes.get(i).setCoverConstraint(coverNodes.get(i).getSignal());
 	}
 	
-	public static void composeSolutionModel(List<SynthesisGraph> solution, SynthesisGraph spec, BioModel solutionModel) throws XMLStreamException, IOException {
+	public static void composeSolutionModel(List<SynthesisGraph> solution, SynthesisGraph spec, BioModel solutionModel) throws XMLStreamException, IOException, BioSimException {
 		List<SynthesisGraph> solutionCopy = new LinkedList<SynthesisGraph>();
 		solutionCopy.addAll(solution);
 		List<SynthesisNode> currentNodes = new LinkedList<SynthesisNode>();
@@ -285,7 +286,7 @@ public class Synthesizer {
 		} while (currentNodes.size() > 0);
 	}
 	
-	private static void composeOutput(SynthesisGraph currentCover, BioModel solutionModel, int submodelIndex) throws XMLStreamException, IOException {
+	private static void composeOutput(SynthesisGraph currentCover, BioModel solutionModel, int submodelIndex) throws XMLStreamException, IOException, BioSimException {
 		currentCover.setSubmodelID("C" + submodelIndex);
 		createSubmodel(currentCover.getSubmodelID(), currentCover.getModelFileID(), solutionModel);
 		Species species = createIOSpecies(currentCover.getOutput().getID(), solutionModel);
@@ -300,7 +301,7 @@ public class Synthesizer {
 	}
 	
 	private static void composeIntermediate(SynthesisGraph currentCover, SynthesisGraph previousCover, BioModel solutionModel, 
-			List<Integer> inputIndices, int submodelIndex) throws XMLStreamException, IOException {
+			List<Integer> inputIndices, int submodelIndex) throws XMLStreamException, IOException, BioSimException {
 		currentCover.setSubmodelID("C" + submodelIndex);
 		createSubmodel(currentCover.getSubmodelID(), currentCover.getModelFileID(), solutionModel);
 		submodelIndex++;
@@ -314,7 +315,7 @@ public class Synthesizer {
 				previousCover.getSubmodelID(), currentCover.getSubmodelID());
 	}
 	
-	private static void createSubmodel(String submodelID, String sbmlFileID, BioModel biomodel) throws XMLStreamException, IOException {
+	private static void createSubmodel(String submodelID, String sbmlFileID, BioModel biomodel) throws XMLStreamException, IOException, BioSimException {
 		BioModel subBiomodel = BioModel.createBioModel(biomodel.getPath(), biomodel);
 		subBiomodel.addObservable(biomodel);
 		subBiomodel.load(biomodel.getPath() + File.separator + sbmlFileID);

--- a/synthesis/src/main/java/edu/utah/ece/async/ibiosim/synthesis/SBMLTechMapping/Synthesizer.java
+++ b/synthesis/src/main/java/edu/utah/ece/async/ibiosim/synthesis/SBMLTechMapping/Synthesizer.java
@@ -315,7 +315,8 @@ public class Synthesizer {
 	}
 	
 	private static void createSubmodel(String submodelID, String sbmlFileID, BioModel biomodel) throws XMLStreamException, IOException {
-		BioModel subBiomodel = new BioModel(biomodel.getPath());
+		BioModel subBiomodel = BioModel.createBioModel(biomodel.getPath(), biomodel);
+		subBiomodel.addObservable(biomodel);
 		subBiomodel.load(biomodel.getPath() + File.separator + sbmlFileID);
 		String md5 = Utility.MD5(subBiomodel.getSBMLDocument());
 		

--- a/synthesis/src/main/java/edu/utah/ece/async/ibiosim/synthesis/assembly/AssemblyGraph2.java
+++ b/synthesis/src/main/java/edu/utah/ece/async/ibiosim/synthesis/assembly/AssemblyGraph2.java
@@ -46,6 +46,7 @@ import edu.utah.ece.async.ibiosim.dataModels.biomodel.parser.BioModel;
 import edu.utah.ece.async.ibiosim.dataModels.biomodel.util.SBMLutilities;
 import edu.utah.ece.async.ibiosim.dataModels.sbol.SBOLFileManager;
 import edu.utah.ece.async.ibiosim.dataModels.util.GlobalConstants;
+import edu.utah.ece.async.ibiosim.dataModels.util.exceptions.BioSimException;
 import edu.utah.ece.async.ibiosim.dataModels.util.exceptions.SBOLException;
 import edu.utah.ece.async.ibiosim.dataModels.util.observe.CoreObservable;
 
@@ -68,7 +69,7 @@ public class AssemblyGraph2 extends CoreObservable{
 	private boolean containsSBOL = false;
 //	//private boolean minusFlag = true;
 	
-	public AssemblyGraph2(BioModel biomodel) throws XMLStreamException, IOException {
+	public AssemblyGraph2(BioModel biomodel) throws XMLStreamException, IOException, BioSimException {
 		assemblyNodes = new HashSet<AssemblyNode2>(); // Initialize map of SBML element meta IDs to assembly nodes they identify
 		assemblyEdges = new HashMap<AssemblyNode2, Set<AssemblyNode2>>(); // Initialize map of assembly node IDs to sets of node IDs (node IDs are SBML meta IDs)
 		SBMLDocument sbmlDoc = biomodel.getSBMLDocument();
@@ -144,7 +145,7 @@ public class AssemblyGraph2 extends CoreObservable{
 	}
 	
 	// Creates assembly nodes for submodels and connects them to the nodes for their input/output species
-	private boolean parseSubModelSBOL(SBMLDocument sbmlDoc, String path, HashMap<String, AssemblyNode2> idToNode) throws XMLStreamException, IOException {
+	private boolean parseSubModelSBOL(SBMLDocument sbmlDoc, String path, HashMap<String, AssemblyNode2> idToNode) throws XMLStreamException, IOException, BioSimException {
 		CompModelPlugin compSBMLModel = SBMLutilities.getCompModelPlugin(sbmlDoc.getModel());
 		CompSBMLDocumentPlugin compSBMLDoc = SBMLutilities.getCompSBMLDocumentPlugin(sbmlDoc);
 		if (compSBMLModel.getListOfSubmodels().size() > 0) {

--- a/synthesis/src/main/java/edu/utah/ece/async/ibiosim/synthesis/assembly/AssemblyGraph2.java
+++ b/synthesis/src/main/java/edu/utah/ece/async/ibiosim/synthesis/assembly/AssemblyGraph2.java
@@ -47,6 +47,7 @@ import edu.utah.ece.async.ibiosim.dataModels.biomodel.util.SBMLutilities;
 import edu.utah.ece.async.ibiosim.dataModels.sbol.SBOLFileManager;
 import edu.utah.ece.async.ibiosim.dataModels.util.GlobalConstants;
 import edu.utah.ece.async.ibiosim.dataModels.util.exceptions.SBOLException;
+import edu.utah.ece.async.ibiosim.dataModels.util.observe.CoreObservable;
 
 /**
  * 
@@ -57,7 +58,7 @@ import edu.utah.ece.async.ibiosim.dataModels.util.exceptions.SBOLException;
  * @author <a href="http://www.async.ece.utah.edu/ibiosim#Credits"> iBioSim Contributors </a>
  * @version %I%
  */
-public class AssemblyGraph2 {
+public class AssemblyGraph2 extends CoreObservable{
 
 	private Set<AssemblyNode2> assemblyNodes;
 	private HashMap<AssemblyNode2, Set<AssemblyNode2>> assemblyEdges;
@@ -160,7 +161,7 @@ public class AssemblyGraph2 {
 				} else {
 					assemblyNodes.remove(subModelNode);
 					String extSBMLFileID = compSBMLDoc.getListOfExternalModelDefinitions().get(sbmlSubModel.getModelRef()).getSource().replace("file://","").replace("file:","").replace(".gcm",".xml");
-					BioModel extBioModel = new BioModel(path);
+					BioModel extBioModel =  BioModel.createBioModel(path, this);
 					extBioModel.load(extSBMLFileID);
 					Model extSBMLModel = extBioModel.getSBMLDocument().getModel();
 					AssemblyNode2 extModelNode = constructNode(extSBMLModel, extSBMLModel.getId());

--- a/verification/src/main/java/edu/utah/ece/async/lema/verification/lpn/LPN.java
+++ b/verification/src/main/java/edu/utah/ece/async/lema/verification/lpn/LPN.java
@@ -140,7 +140,7 @@ public class LPN extends CoreObservable {
 	}
 	
 	public static LPN convertToLHPN(ArrayList<String> specs, ArrayList<Object[]> conLevel, MutableString lpnProperty,
-			BioModel bioModel) throws XMLStreamException, IOException {
+			BioModel bioModel) throws XMLStreamException, IOException, BioSimException {
 		GCMParser parser = new GCMParser(bioModel);
 		SBMLDocument sbml = bioModel.flattenModel(true);	
 		if (sbml == null) return null;


### PR DESCRIPTION
Static methods with messages should take observers and observables as parameters. SBML core panels are now displaying error messages. Error messages can be displayed as scrollable text box for long messages. Fixed #458 and #186 