### PR TITLE
Fixes for sweep

### DIFF
--- a/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/Analysis.java
+++ b/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/Analysis.java
@@ -268,7 +268,7 @@ public class Analysis implements BioObserver
       }
       loadUserValues(propertiesMap);
       AnalysisPropertiesWriter.createProperties(properties);
-      run.execute();
+      run.execute(properties.getDirectory(),properties.getFilename());
     }
   }
 
@@ -442,7 +442,7 @@ public class Analysis implements BioObserver
       String newFilename = root + File.separator + task.getId() + File.separator + modelSource;
       SBMLWriter.write(flatten, newFilename, ' ', (short) 2);
       AnalysisPropertiesWriter.createProperties(properties);
-      run.execute();
+      run.execute(properties.getDirectory(),properties.getFilename());
     }
     for (Output output : sedml.getOutputs()) 
     {

--- a/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/properties/AnalysisProperties.java
+++ b/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/properties/AnalysisProperties.java
@@ -77,7 +77,7 @@ public final class AnalysisProperties extends CoreObservable
   private final String[] hse2Command = new String[]{Executables.reb2sacExecutable, "--target.encoding=hse2", null};
   private final String[] atacsCommand = new String[]{"atacs", "-T0.000001", "-oqoflhsgllvA", null, "out.hse"};
   private final String[] sbmlCommand = new String[]{Executables.reb2sacExecutable, "--target.encoding=sbml", null, null};
-  private final String[] reb2sacCommand = new String[]{Executables.reb2sacExecutable, null,null };
+  private final String[] reb2sacCommand = new String[]{Executables.reb2sacExecutable, null,null, null };
   private final String[] dotCommand = new String[]{Executables.reb2sacExecutable, "--target.encoding=dot",  null, null};
   private final String[] xhtmlCommand = new String[]{Executables.reb2sacExecutable, "--target.encoding=xhtml", null, null};
   private final String[] openBrowserCommand = new String[2];
@@ -738,10 +738,11 @@ public final class AnalysisProperties extends CoreObservable
    * 
    * @return command for reb2sac simulation.
    */
-  public String[] getReb2sacCommand()
+  public String[] getReb2sacCommand(String filename)
   {
     reb2sacCommand[1] = "--target.encoding=" + sim;
-    reb2sacCommand[2] = filename;
+    reb2sacCommand[2] = "--reb2sac.properties.file=" + this.getPropertiesFilename();
+    reb2sacCommand[3] = filename;
     return reb2sacCommand;
   }
   

--- a/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/simulation/DynamicSimulation.java
+++ b/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/simulation/DynamicSimulation.java
@@ -65,14 +65,14 @@ public class DynamicSimulation extends CoreObservable
     message = new Message();
   }
 
-  public void simulate(AnalysisProperties properties)
+  public void simulate(AnalysisProperties properties,String filename)
   {
     SimulationProperties simProperties = properties.getSimulationProperties();
 
     try
     {
 
-      String SBMLFileName = properties.getFilename(), outputDirectory = properties.getOutDir().equals(".") ? properties.getDirectory() : properties.getOutDir(), rootDirectory = properties.getRoot(), quantityType = simProperties.getPrinter_track_quantity();
+      String SBMLFileName = filename, outputDirectory = properties.getOutDir().equals(".") ? properties.getDirectory() : properties.getOutDir(), rootDirectory = properties.getRoot(), quantityType = simProperties.getPrinter_track_quantity();
       double timeLimit = simProperties.getTimeLimit(), maxTimeStep = simProperties.getMaxTimeStep(), minTimeStep = simProperties.getMinTimeStep(), printInterval = simProperties.getPrintInterval(), stoichAmpValue = properties.getAdvancedProperties().getStoichAmp(),
           initialTime = simProperties.getInitialTime(), outputStartTime = simProperties.getOutputStartTime(), absError = simProperties.getAbsError(), relError = simProperties.getRelError();
       long randomSeed = simProperties.getRndSeed();

--- a/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/simulation/flattened/DynSim.java
+++ b/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/simulation/flattened/DynSim.java
@@ -173,14 +173,14 @@ public class DynSim
 			System.out.println("Flattening time: " + (t2 - t1) / 1000);
 			if (testSuite)
 			{
-				simulator.simulate(properties);
+				simulator.simulate(properties,properties.getFilename());
 
 				TSDParser tsdp = new TSDParser(outputDirectory + "run-1.tsd", true);
 				tsdp.outputCSV(outputDirectory + testcase + ".csv");
 			}
 			else
 			{
-				simulator.simulate(properties);
+				simulator.simulate(properties,properties.getFilename());
 			}
 
 		}

--- a/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/simulation/hierarchical/util/scripts/HierarchicalSimulatorRunner.java
+++ b/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/simulation/hierarchical/util/scripts/HierarchicalSimulatorRunner.java
@@ -130,7 +130,7 @@ public class HierarchicalSimulatorRunner
 			try
 			{
 
-				simulator.simulate(properties);
+				simulator.simulate(properties,properties.getFilename());
 
 				TSDParser tsdp = new TSDParser(outputDirectory + "run-1.tsd", true);
 				tsdp.outputCSV(outputDirectory + testcase + ".csv");
@@ -186,11 +186,11 @@ public class HierarchicalSimulatorRunner
 					double t2 = System.currentTimeMillis();
 					System.out.println("Flattening time: " + (t2 - t1) / 1000);
 
-					simulator.simulate(properties);
+					simulator.simulate(properties,properties.getFilename());
 				}
 				else
 				{
-					simulator.simulate(properties);
+					simulator.simulate(properties,properties.getFilename());
 				}
 
 			}

--- a/analysis/src/test/java/edu/utah/ece/async/ibiosim/analysis/simulation/hierarchical/HierarchicalTestSuiteRunner.java
+++ b/analysis/src/test/java/edu/utah/ece/async/ibiosim/analysis/simulation/hierarchical/HierarchicalTestSuiteRunner.java
@@ -146,7 +146,7 @@ public class HierarchicalTestSuiteRunner
       try
       {
 
-        simulator.simulate(properties);
+        simulator.simulate(properties,properties.getFilename());
 
         TSDParser tsdp = new TSDParser(outputDirectory + "run-1.tsd", true);
         tsdp.outputCSV(outputDirectory + testcase + ".csv");

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/Gui.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/Gui.java
@@ -3811,7 +3811,7 @@ public class Gui implements BioObserver, MouseListener, ActionListener, MouseMot
 	    AnalysisPropertiesWriter.createProperties(properties);
 		Run run = new Run(properties);
 	    run.addObserver(this);
-	    run.execute();
+	    run.execute(properties.getDirectory(),properties.getFilename());
 	}
 
 	private HashMap<String, String> importModels(String path, SedML sedml, ArchiveComponents ac)

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/analysisView/AnalysisThread.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/analysisView/AnalysisThread.java
@@ -24,10 +24,13 @@ public class AnalysisThread extends Thread {
 	private AnalysisView analysisView;
 
 	private boolean refresh;
+	
+	private String direct = ".";
 
-	public AnalysisThread(AnalysisView analysisView) {
+	public AnalysisThread(AnalysisView analysisView, String direct) {
 		super(analysisView);
 		this.analysisView = analysisView;
+		this.direct = direct;
 	}
 
 	public void start(boolean refresh) {
@@ -37,6 +40,6 @@ public class AnalysisThread extends Thread {
 
 	@Override
 	public void run() {
-		analysisView.run(refresh);
+		analysisView.run(refresh,direct);
 	}
 }

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/analysisView/AnalysisView.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/analysisView/AnalysisView.java
@@ -839,7 +839,7 @@ public class AnalysisView extends PanelObservable implements ActionListener, Run
    * @throws XMLStreamException
    * @throws NumberFormatException
    */
-  public void run(boolean refresh)
+  public void run(boolean refresh, String direct)
   {
     if (!save())
     {
@@ -848,6 +848,12 @@ public class AnalysisView extends PanelObservable implements ActionListener, Run
     String root = properties.getRoot();
     String outDir = properties.getDirectory();
     String simName = properties.getSim();
+    String filename = properties.getFilename();
+    
+    if (direct!=null && !direct.equals(".")) {
+    	outDir = outDir + File.separator + direct;
+    	filename = outDir + File.separator + properties.getModelFile();
+    }
 
     if (monteCarlo.isSelected() || ODE.isSelected())
     {
@@ -894,7 +900,7 @@ public class AnalysisView extends PanelObservable implements ActionListener, Run
       }
     }
     try {
-      exit = runProgram.execute();
+      exit = runProgram.execute(outDir,filename);
       if (stateAbstraction.isSelected() && modelEditor == null && !simName.contains("markov-chain-analysis") && exit == 0)
       {
         //      simProp = simProp.replace("\\", "/");
@@ -1451,7 +1457,8 @@ public class AnalysisView extends PanelObservable implements ActionListener, Run
   {
     String simName = properties.getId();
 
-    String outDir = properties.getDirectory();
+    String outDir = properties.getDirectory();   // TODO: not sure about this for sweeps
+    String filename = properties.getFilename();  // TODO: not sure about this for sweeps
     String printer_id = "tsd.printer";
     String printer_track_quantity = "amount";
     if (concentrations.isSelected())
@@ -1465,6 +1472,7 @@ public class AnalysisView extends PanelObservable implements ActionListener, Run
   {
     boolean ignoreSweep = false;
     String modelFile = properties.getModelFile();
+    String filename = properties.getFilename();  // TODO: not sure about this for sweeps
 
     if (sbml.isSelected() || dot.isSelected() || xhtml.isSelected())
     {
@@ -1537,7 +1545,7 @@ public class AnalysisView extends PanelObservable implements ActionListener, Run
       {
         try {
           LPN lhpnFile = new LPN();
-          lhpnFile.load(properties.getFilename());
+          lhpnFile.load(filename);
           Abstraction abst = new Abstraction(lhpnFile, properties.getVerificationProperties().getAbsProperty());
           abst.abstractSTG(false);
           abst.save(properties.getDirectory() + File.separator + modelFile);
@@ -1577,7 +1585,7 @@ public class AnalysisView extends PanelObservable implements ActionListener, Run
       }
       t1.setFilename(properties.getDirectory() + File.separator + modelFile.replace(".lpn", ".xml"));
       t1.outputSBML();
-      new AnalysisThread(this).start(true);
+      new AnalysisThread(this, ".").start(true);
     }
   }
 

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/sbol/SBOLInputDialog.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/sbol/SBOLInputDialog.java
@@ -108,7 +108,7 @@ public class SBOLInputDialog extends InputDialog<SBOLDocument> {
 	private JCheckBox showRootDefs;
 	private JRadioButton showModDefs, showCompDefs;
 	
-	private JButton openSBOLDesigner, openVPRGenerator, optionsButton, cancelButton;
+	private JButton openSBOLDesigner, openVPRGenerator, optionsButton; //, cancelButton;
 
 	private SBOLDocument sbolDesigns;
 	

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/schematic/ModelEditor.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/schematic/ModelEditor.java
@@ -1182,7 +1182,9 @@ public class ModelEditor extends PanelObservable implements ActionListener, Mous
 											.replace("-| ", "").replace("x> ", "").replace("\"", "").replace(" ", "_")
 											.replace(",", "")).mkdir();
 							createSBML(stem, sweepTwo, analysisMethod);
-							AnalysisThread thread = new AnalysisThread(analysisView);
+							sweepTwo = sweepTwo.replace("/", "-").replace("-> ", "").replace("+> ", "").replace("-| ", "").replace("x> ", "")
+									.replace("\"", "").replace(" ", "_").replace(",", "").replace("=","_").replace(".", "_");
+							AnalysisThread thread = new AnalysisThread(analysisView, sweepTwo);
 							String simStem = stem + sweepTwo.replace("/", "-").replace("-> ", "").replace("+> ", "")
                   .replace("-| ", "").replace("x> ", "").replace("\"", "").replace(" ", "_")
                   .replace(",", "");
@@ -1202,11 +1204,13 @@ public class ModelEditor extends PanelObservable implements ActionListener, Mous
 										.replace("x> ", "").replace("\"", "").replace(" ", "_").replace(",", "")
 										.replace("=", "_").replaceAll("-", "_").replace(".","_"))
 												.mkdir();
-						analysisView.setFileStem(sweep.replace("/", "-").replace("-> ", "").replace("+> ", "").replace("-| ", "")
-										.replace("x> ", "").replace("\"", "").replace(" ", "_").replace(",", "").replace("=", "_")
-										.replaceAll("-", "_").replace(".","_"));
+//						analysisView.setFileStem(sweep.replace("/", "-").replace("-> ", "").replace("+> ", "").replace("-| ", "")
+//										.replace("x> ", "").replace("\"", "").replace(" ", "_").replace(",", "").replace("=", "_")
+//										.replaceAll("-", "_").replace(".","_"));
 						createSBML(stem, sweep, analysisMethod);
-						AnalysisThread thread = new AnalysisThread(analysisView);
+						sweep = sweep.replace("/", "-").replace("-> ", "").replace("+> ", "").replace("-| ", "").replace("x> ", "")
+								.replace("\"", "").replace(" ", "_").replace(",", "").replace("=","_").replace(".", "_");
+						AnalysisThread thread = new AnalysisThread(analysisView, sweep);
 						thread.start(false);
 						threads.add(thread);
 						dirs.add(sweep.replace("/", "-").replace("-> ", "").replace("+> ", "").replace("-| ", "")
@@ -1227,7 +1231,7 @@ public class ModelEditor extends PanelObservable implements ActionListener, Mous
 //					new File(path + File.separator + simName + File.separator + stem).mkdir();
 //				}
 				if (createSBML(stem, ".", analysisMethod)) {
-						new AnalysisThread(analysisView).start(true);
+						new AnalysisThread(analysisView, ".").start(true);
 				}
 				// analysisView.emptyFrames();
 			}
@@ -1754,7 +1758,7 @@ public class ModelEditor extends PanelObservable implements ActionListener, Mous
 			}
 		}
 		direct = direct.replace("/", "-").replace("-> ", "").replace("+> ", "").replace("-| ", "").replace("x> ", "")
-				.replace("\"", "").replace(" ", "_").replace(",", "");
+				.replace("\"", "").replace(" ", "_").replace(",", "").replace("=","_").replace(".", "_");
 		if (direct.equals(".") && !stem.equals("")) {
 			direct = "";
 		}

--- a/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/schematic/ModelEditor.java
+++ b/gui/src/main/java/edu/utah/ece/async/ibiosim/gui/modelEditor/schematic/ModelEditor.java
@@ -1757,11 +1757,11 @@ public class ModelEditor extends PanelObservable implements ActionListener, Mous
 				}
 			}
 		}
-		direct = direct.replace("/", "-").replace("-> ", "").replace("+> ", "").replace("-| ", "").replace("x> ", "")
-				.replace("\"", "").replace(" ", "_").replace(",", "").replace("=","_").replace(".", "_");
-		if (direct.equals(".") && !stem.equals("")) {
+		if (direct.equals(".") /*&& !stem.equals("")*/) {
 			direct = "";
 		}
+		direct = direct.replace("/", "-").replace("-> ", "").replace("+> ", "").replace("-| ", "").replace("x> ", "")
+				.replace("\"", "").replace(" ", "_").replace(",", "").replace("=","_").replace(".", "_");
 		if (analysisMethod != null && !analysisMethod.contains("Hierarchical") && !analysisMethod.contains("Mixed")) {
 			SBMLDocument sbml;
 			try {
@@ -1778,11 +1778,11 @@ public class ModelEditor extends PanelObservable implements ActionListener, Mous
 				return false;
 			}
 			catch (BioSimException e) {
-        JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
-          JOptionPane.ERROR_MESSAGE);
-        e.printStackTrace();
-        return false;
-      }
+				JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+						JOptionPane.ERROR_MESSAGE);
+				e.printStackTrace();
+				return false;
+			}
 			if (sbml == null) {
 				JOptionPane.showMessageDialog(Gui.frame, "Invalid XML in SBML file", "Error Checking File",
 						JOptionPane.ERROR_MESSAGE);
@@ -1853,10 +1853,10 @@ public class ModelEditor extends PanelObservable implements ActionListener, Mous
 				e.printStackTrace();
 			}
 			catch (BioSimException e) {
-        JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
-          JOptionPane.ERROR_MESSAGE);
-        e.printStackTrace();
-      }
+				JOptionPane.showMessageDialog(Gui.frame, e.getMessage(), e.getTitle(),
+						JOptionPane.ERROR_MESSAGE);
+				e.printStackTrace();
+			}
 		}
 		return true;
 	}


### PR DESCRIPTION
Fixes to make sweeping work again for reb2sac.  Still not working for Java simulators but no error.  The key problem is the properties cannot be used for sweep output directories and filenames, since these vary on each run of the sweep.  Since this is threaded there are issues with it looking at a single static property, so it instead passes the output directory to the AnalysisThread constructor.
