### PR TITLE
Add CI Maven build with GitHub Actions and iBioSim.jar as a downloadable artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,44 @@
+name: build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+
+    - name: Cache Maven packages
+      uses: actions/cache@v2.1.1
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+      
+    - name: Build iBioSim with Maven
+      run: mvn -B package -Dmaven.javadoc.skip=true --file pom.xml
+
+    - name: Write README
+      run: echo 'Download latest release from https://github.com/MyersResearchGroup/iBioSim/releases/ and REPLACE iBioSim.jar inside bin/' > README.txt
+
+    - name: Prepare artifacts (GUI executable jar as GitHub Artifact)
+      run: mkdir artifacts && cp -v README.txt artifacts/ && cp -v gui/target/*jar-with-dependencies.jar artifacts/iBioSim.jar
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2.1.4
+      with:
+        # Artifact name with commit hash
+        name: iBioSim-gui-SNAPSHOT-${{ github.sha }}
+        # A file, directory or wildcard pattern that describes what to upload
+        path: artifacts
+        if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
   <img  src="docs/media/iBioSim_horizontal.png" width=300>
 </p>
 
+[![build](https://github.com/MyersResearchGroup/iBioSim/workflows/build/badge.svg)](https://github.com/MyersResearchGroup/iBioSim/actions)
+
 iBioSim is a computer-aided design (CAD) tool aimed for the modeling, analysis, and design of genetic circuits. 
 While iBioSim primarily targets models of genetic circuits, models representing metabolic networks, cell-signaling pathways, 
 and other biological and chemical systems can also be analyzed. 


### PR DESCRIPTION
This CI config file will trigger a build each time a pull request or push is made. 
Build status (correct or incorrect compilation) will be visible in README.md and next to commit hashes on GitHub.

![image](https://user-images.githubusercontent.com/45542433/94375314-1d267c80-0113-11eb-851c-e304842b6f2c.png)


The compiled binaries can also be uploaded as artifacts to GitHub (currently I decided to only upload the GUI jar).

![image](https://user-images.githubusercontent.com/45542433/94375131-ac329500-0111-11eb-8a79-61d595697682.png)

![image](https://user-images.githubusercontent.com/45542433/94375207-485c9c00-0112-11eb-98d0-1f9aa776118e.png)

Nevertheless, it is still required to manually update the shared libraries such as libsbml to the pom.xml specified version so a short README.txt is provided inside the artifact compressed file with the following contents:

"Download latest release from https://github.com/MyersResearchGroup/iBioSim/releases/ and REPLACE iBioSim.jar inside bin/"

This improves testing on recent upstream changes without requiring to recompile the project in your computer.

