### PR TITLE
Fix headless stdout flooding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ bin/iBioSim.jar
 .settings/
 **/.project
 /.metadata/
+.sdkmanrc
 
 # intellij artefacts
 out

--- a/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/Run.java
+++ b/analysis/src/main/java/edu/utah/ece/async/ibiosim/analysis/Run.java
@@ -876,9 +876,11 @@ public class Run extends CoreObservable implements ActionListener {
 				  String line = br.readLine ();
 				  if (line == null) break;
 				  if (name.equals("stdin")) {
+					  boolean isProgress = false;
 					  try {
 						  if (line.contains("Time")) {
 							  time = Double.parseDouble(line.substring(line.indexOf('=') + 1, line.length()));
+							  isProgress = true;
 							  if (oldTime > time) {
 								  runNum++;
 							  }
@@ -900,7 +902,7 @@ public class Run extends CoreObservable implements ActionListener {
 					  if (parent!=null) {
 						  message.setInteger(prog);
 						  parent.send(RequestType.REQUEST_PROGRESS, message);
-					  } else{
+					  } else if (!isProgress) {
 						  System.out.println(line);
 					  }
 				  } else {

--- a/dataModels/pom.xml
+++ b/dataModels/pom.xml
@@ -24,7 +24,7 @@
 		<repository>
 			<id>osgeo</id>
 			<name>osgeo</name>
-			<url>http://download.osgeo.org/webdav/geotools/</url>
+			<url>https://download.osgeo.org/webdav/geotools/</url>
 		</repository>
 		<repository>
 			<id>alfresco</id>
@@ -80,6 +80,27 @@
 			<groupId>org.sbml.jsbml</groupId>
 			<artifactId>jsbml</artifactId>
 			<version>1.7-SNAPSHOT</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<version>4.5.3</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpcore</artifactId>
+			<version>4.4.6</version>
+		</dependency>
+		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<version>2.7</version>
+		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>18.0</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Running simulations through SynBioSuite can fail with `ERR_CHILD_PROCESS_STDIO_MAXBUFFER` when reb2sac progress output overflows Node.js's buffer in iBioSim-API. In headless mode, `Run.java` dumps every progress line (`Time=X`) to stdout, but nothing downstream uses them, they just accumulate until the buffer overflows.

- Skip `System.out.println` for lines successfully parsed as progress updates. Diagnostic output (warnings, errors) still prints.
- GUI path is unchanged, progress still goes through `parent.send()`.
- Add explicit transitive deps to `dataModels/pom.xml` so the module builds standalone.
- Fix http to https for osgeo Maven repo URL.
- Ignore `.sdkmanrc` in `.gitignore`.